### PR TITLE
Removes an article from Instant Articles library

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -102,6 +102,10 @@ class Client
      *
      * @param $canonicalURL
      * @return \Facebook\InstantArticles\Client\InstantArticleStatus
+     *
+     * @todo Consider returning the \Facebook\FacebookResponse object sent by
+     *   \Facebook\Facebook::delete(). For now we trust that if an Instant
+     *   Article ID exists for the Canonical URL the delete operation will work.
      */
     public function removeArticle($canonicalURL)
     {

--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -117,7 +117,7 @@ class Client
 
         if ($articleID = $this->getArticleIDFromCanonicalURL($canonicalURL)) {
             $this->facebook->delete($articleID);
-            return InstantArticleStatus::success(array('An Instant Article ID ' . $articleID . ' was found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.'));
+            return InstantArticleStatus::success();
         }
         return InstantArticleStatus::notFound(array('An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.'));
     }

--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -100,7 +100,7 @@ class Client
     /**
      * Removes an article from your Instant Articles library.
      *
-     * @param $canonicalURL
+     * @param string $canonicalURL The canonical URL of the article to delete.
      * @return \Facebook\InstantArticles\Client\InstantArticleStatus
      *
      * @todo Consider returning the \Facebook\FacebookResponse object sent by

--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -98,6 +98,17 @@ class Client
     }
 
     /**
+     * Removes an article from your Instant Articles library.
+     *
+     * @param string $canonicalURL The canonical URL of the article to get the status for.
+     */
+    public function removeArticle($canonicalURL) {
+        if ($articleID = $this->getArticleIDFromCanonicalURL($canonicalURL)) {
+            $this->facebook->delete($articleID);
+        }
+    }
+
+    /**
      * Get an Instant Article ID on its canonical URL.
      *
      * @param string $canonicalURL The canonical URL of the article to get the status for.

--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -100,7 +100,7 @@ class Client
     /**
      * Removes an article from your Instant Articles library.
      *
-     * @param string $canonicalURL The canonical URL of the article to get the status for.
+     * @param string $canonicalURL The canonical URL of the article to delete.
      */
     public function removeArticle($canonicalURL) {
         if ($articleID = $this->getArticleIDFromCanonicalURL($canonicalURL)) {

--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -100,12 +100,22 @@ class Client
     /**
      * Removes an article from your Instant Articles library.
      *
-     * @param string $canonicalURL The canonical URL of the article to delete.
+     * @param $canonicalURL
+     * @return \Facebook\InstantArticles\Client\InstantArticleStatus
      */
-    public function removeArticle($canonicalURL) {
+    public function removeArticle($canonicalURL)
+    {
+        if (!$canonicalURL) {
+            return InstantArticleStatus::notFound(array('$canonicalURL param not passed to ' . __FUNCTION__ . '.'));
+        }
+
+        Type::enforce($canonicalURL, Type::STRING);
+
         if ($articleID = $this->getArticleIDFromCanonicalURL($canonicalURL)) {
             $this->facebook->delete($articleID);
+            return InstantArticleStatus::success(array('An Instant Article ID ' . $articleID . ' was found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.'));
         }
+        return InstantArticleStatus::notFound(array('An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.'));
     }
 
     /**

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -64,6 +64,39 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->importArticle($this->article, true);
     }
 
+    /**
+     * Tests removing an article from an Instant Articles library.
+     *
+     * @covers Facebook\InstantArticles\Client\Client::removeArticle()
+     */
+    public function testRemoveArticle()
+    {
+        $canonicalURL = 'http://facebook.com';
+        $articleID = '1';
+
+        // Use a mocked client with stubbed getArticleIDFromCanonicalURL().
+        $this->client = $this->getMockBuilder('Facebook\InstantArticles\Client\Client')
+          ->setMethods(array('getArticleIDFromCanonicalURL'))
+          ->setConstructorArgs(array(
+            $this->facebook,
+            "PAGE_ID",
+            true // developmentMode
+          ))->getMock();
+
+        $this->client
+          ->expects($this->once())
+          ->method('getArticleIDFromCanonicalURL')
+          ->with($canonicalURL)
+          ->will($this->returnValue($articleID));;
+
+        $this->facebook
+          ->expects($this->once())
+          ->method('delete')
+          ->with($articleID);
+
+        $this->client->removeArticle($canonicalURL);
+    }
+
     public function testImportArticleDevelopmentMode()
     {
         $this->client = new Client(


### PR DESCRIPTION
Hey guys, would this be a valuable method for `Facebook\InstantArticles\Client`? I know it's basically a wrapper for the graph API, but this lets us easily make use of the `getArticleIDFromCanonicalURL()` method, and may be nice to have an easy wrapper.

Anyway, if you think it makes sense, should we throw an exception if the article URL doesn't exist?