### PR TITLE
Methods for manipualting the rule stack

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer;
 
 use Facebook\InstantArticles\Transformer\Warnings\UnrecognizedElement;
+use Facebook\InstantArticles\Transformer\Rules\Rule;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Validators\Type;
 
@@ -28,6 +29,7 @@ class Transformer
 
     public function addRule($rule)
     {
+        Type::enforce($rule, Rule::class);
         // Adds in reversed order for bottom-top processing rules
         array_unshift($this->rules, $rule);
     }
@@ -106,5 +108,34 @@ class Transformer
                 $this->addRule($factory_method->invoke(null, $configuration_rule));
             }
         }
+    }
+
+    /**
+     * Removes all rules already set in this transformer instance.
+     */
+    public function resetRules()
+    {
+        $this->rules = array();
+    }
+
+    /**
+     * Gets all rules already set in this transformer instance.
+     *
+     * @return array List of configured rules.
+     */
+    public function getRules()
+    {
+        return $this->rules;
+    }
+
+    /**
+     * Overrides all rules already set in this transformer instance.
+     *
+     * @return array List of configured rules.
+     */
+    public function setRules($rules)
+    {
+        Type::enforceArrayOf($rules, Rule::class);
+        $this->rules = $rules;
     }
 }

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -79,4 +79,34 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         // print_r($warnings);
         $this->assertEquals($html_file, $result);
     }
+
+    public function testTransformerAddAndGetRules()
+    {
+        $transformer = new Transformer();
+        $rule1 = new ParagraphRule();
+        $rule2 = new ItalicRule();
+        $transformer->addRule($rule1);
+        $transformer->addRule($rule2);
+        $this->assertEquals(array($rule2, $rule1), $transformer->getRules());
+    }
+
+    public function testTransformerSetRules()
+    {
+        $transformer = new Transformer();
+        $rule1 = new ParagraphRule();
+        $rule2 = new ItalicRule();
+        $transformer->setRules(array($rule1, $rule2));
+        $this->assertEquals(array($rule1, $rule2), $transformer->getRules());
+    }
+
+    public function testTransformerResetRules()
+    {
+        $transformer = new Transformer();
+        $rule1 = new ParagraphRule();
+        $rule2 = new ItalicRule();
+        $transformer->addRule($rule1);
+        $transformer->addRule($rule2);
+        $transformer->resetRules();
+        $this->assertEquals(array(), $transformer->getRules());
+    }
 }


### PR DESCRIPTION
These methods are useful when a plugin needs to manipulate the rule stack of the transformer.