### PR TITLE
Fix type hints in the doc block for Elements.

### DIFF
--- a/src/Facebook/InstantArticles/Elements/GeoTag.php
+++ b/src/Facebook/InstantArticles/Elements/GeoTag.php
@@ -43,7 +43,7 @@ class GeoTag extends Element
 
     /**
      * Private constructor.
-     * @see Map::create();.
+     * @see GeoTag::create();.
      */
     private function __construct()
     {
@@ -51,7 +51,7 @@ class GeoTag extends Element
 
     /**
      * Factory method for the Map
-     * @return Map the new instance
+     * @return GeoTag the new instance
      */
     public static function create()
     {

--- a/src/Facebook/InstantArticles/Elements/ListElement.php
+++ b/src/Facebook/InstantArticles/Elements/ListElement.php
@@ -49,7 +49,7 @@ class ListElement extends Element
 
     /**
      * Factory method for an Ordered list
-     * @return the new instance List as an ordered list
+     * @return ListElement the new instance List as an ordered list
      */
     public static function createOrdered()
     {
@@ -61,7 +61,7 @@ class ListElement extends Element
 
     /**
      * Factory method for an unrdered list
-     * @return the new instance List as an unordered list
+     * @return ListElement the new instance List as an unordered list
      */
     public static function createUnordered()
     {

--- a/src/Facebook/InstantArticles/Elements/RelatedArticles.php
+++ b/src/Facebook/InstantArticles/Elements/RelatedArticles.php
@@ -49,7 +49,7 @@ class RelatedArticles extends Element
 
     /**
      * Factory method for the RelatedArticles list
-     * @return the new instance of RelatedArticles
+     * @return RelatedArticles the new instance of RelatedArticles
      */
     public static function create()
     {

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -116,7 +116,7 @@ class Video extends Element
 
     /**
      * Factory method
-     * @return the new instance from Video
+     * @return Video the new instance from Video
      */
     public static function create()
     {


### PR DESCRIPTION
While working with the API in PHPStorm, I noticed that the doc blocks for some Element::create() methods were missing in such a way that auto-complete wouldn't work with those Element objects.