### PR TITLE
Anchor inside ListItem tags. <li> <a href="#">link</a> </li>

### DIFF
--- a/src/Facebook/InstantArticles/Elements/ListElement.php
+++ b/src/Facebook/InstantArticles/Elements/ListElement.php
@@ -80,7 +80,7 @@ class ListElement extends Element
     {
         Type::enforce($new_item, array(ListItem::getClassName(), Type::STRING));
         if (Type::is($new_item, Type::STRING)) {
-            $new_item = ListItem::create()->withText($new_item);
+            $new_item = ListItem::create()->appendText($new_item);
         }
         $this->items[] = $new_item;
 

--- a/src/Facebook/InstantArticles/Elements/ListItem.php
+++ b/src/Facebook/InstantArticles/Elements/ListItem.php
@@ -33,39 +33,7 @@ class ListItem extends TextContainer
     }
 
     /**
-     * @param string|TextContainer $text the text that will be added to <li>
-     */
-    public function withText($text)
-    {
-        Type::enforce($text, array(TextContainer::getClassName(), Type::STRING));
-        $this->text = $text;
-
-        return $this;
-    }
-
-    /**
-     * Overrides the appendText to make sure only one child will be setted on this ListItem.
-     * If appendText is called multiple times, it will store only the last one.
-     * @see ListItem::withText()
-     *
-     * @param string|TextContainer The content can be a string or a TextContainer.
-     */
-    public function appendText($child)
-    {
-        return $this->withText($child);
-    }
-
-
-    /**
-     * @return string|TextContainer The text that was added thru @see ListItem::withText()
-     */
-    public function getText()
-    {
-        return $this->text;
-    }
-
-    /**
-     * Structure and create the full ListItem in a DOMElement.
+     * Structure and create the full ListItem <li> in a DOMElement.
      *
      * @param DOMDocument $document - The document where this element will be appended (optional).
      */
@@ -76,13 +44,7 @@ class ListItem extends TextContainer
         }
         $list_item = $document->createElement('li');
 
-        if ($this->text) {
-            if (Type::is($this->text, Type::STRING)) {
-                $list_item->appendChild($document->createTextNode($this->text));
-            } else {
-                $list_item->appendChild($this->text->toDOMElement($document));
-            }
-        }
+        $list_item->appendChild($this->textToDOMDocumentFragment($document));
 
         return $list_item;
     }

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -32,7 +32,7 @@ abstract class TextContainer extends Element
      */
     public function appendText($child)
     {
-        Type::enforce($child, array(Type::STRING, FormattedText::getClassName()));
+        Type::enforce($child, array(Type::STRING, FormattedText::getClassName(), TextContainer::getClassName()));
         $this->textChildren[] = $child;
 
         return $this;

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -92,9 +92,9 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
     {
         $list =
             ListElement::createUnordered()
-                ->addItem(ListItem::create()->withText(Paragraph::create()->appendText('Item 1')))
-                ->addItem(ListItem::create()->withText(Div::create()->appendText('Item 2')))
-                ->addItem(ListItem::create()->withText(Span::create()->appendText('Item 3')));
+                ->addItem(ListItem::create()->appendText(Paragraph::create()->appendText('Item 1')))
+                ->addItem(ListItem::create()->appendText(Div::create()->appendText('Item 2')))
+                ->addItem(ListItem::create()->appendText(Span::create()->appendText('Item 3')));
 
         $expected =
             '<ul>'.

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
@@ -84,7 +84,7 @@
         <li>One paragraph on the list</li>
         <li>On the span</li>
         <li>Text inside div?</li>
-        <li>Other paragraph on the li</li>
+        <li>Other <a href="#">paragraph</a> on the li</li>
         <li>Last list item</li>
       </ol>
       <p>Some text to be within a paragraph for testing.</p>


### PR DESCRIPTION
It fixes <a href=''></a> inside <li>. 
Fixes # https://github.com/Automattic/facebook-instant-articles-wp/issues/121