### PR TITLE
Allow H1 and H2 in Header

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -624,9 +624,11 @@ These rule classes differ slightly from the others because they are permitted in
   - ***Map***
 - `H1Rule`
   - ***Caption***
+  - ***Header***
   - ***InstantArticle***
 - `H2Rule`
   - ***Caption***
+  - ***Header***
   - ***InstantArticle***
 
 ##### Special Rule Classes

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -235,7 +235,7 @@ class Header extends Element
     }
 
     /**
-     * @return string $title The title of the InstantArticle
+     * @return string|H1 $title The title of the InstantArticle
      */
     public function getTitle()
     {
@@ -243,7 +243,7 @@ class Header extends Element
     }
 
     /**
-     * @return string $subtitle The subtitle of the InstantArticle
+     * @return string|H2 $subtitle The subtitle of the InstantArticle
      */
     public function getSubtitle()
     {
@@ -317,7 +317,7 @@ class Header extends Element
         }
 
         if ($this->subtitle) {
-            if (Type::is($this->title, Type::STRING)) {
+            if (Type::is($this->subtitle, Type::STRING)) {
                 $sub_title_element = $document->createElement('h2');
                 $sub_title_element->appendChild($document->createTextNode($this->subtitle));
                 $element->appendChild($sub_title_element);

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -308,13 +308,17 @@ class Header extends Element
 
         if ($this->title) {
             $title_element = $document->createElement('h1');
-            $title_element->appendChild($document->createTextNode($this->title));
+            $title_fragment = $document->createDocumentFragment();
+            $title_fragment->appendXML($this->title);
+            $title_element->appendChild($title_fragment);
             $element->appendChild($title_element);
         }
 
         if ($this->subtitle) {
             $sub_title_element = $document->createElement('h2');
-            $sub_title_element->appendChild($document->createTextNode($this->subtitle));
+            $sub_title_fragment = $document->createDocumentFragment();
+            $sub_title_fragment->appendXML($this->subtitle);
+            $sub_title_element->appendChild($sub_title_fragment);
             $element->appendChild($sub_title_element);
         }
 

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -46,12 +46,12 @@ class Header extends Element
     private $cover;
 
     /**
-     * string The title of the Article that will be displayed on header.
+     * string|H1 The title of the Article that will be displayed on header.
      */
     private $title;
 
     /**
-     * string The subtitle of the Article that will be displayed on header.
+     * string|H2 The subtitle of the Article that will be displayed on header.
      */
     private $subtitle;
 
@@ -104,11 +104,11 @@ class Header extends Element
 
     /**
      * Sets the title of InstantArticle
-     * @param string $title The title of the InstantArticle
+     * @param string|H1 $title The title of the InstantArticle
      */
     public function withTitle($title)
     {
-        Type::enforce($title, Type::STRING);
+        Type::enforce($title, array(Type::STRING, H1::getClassName()));
         $this->title = $title;
 
         return $this;
@@ -116,11 +116,11 @@ class Header extends Element
 
     /**
      * Sets the subtitle of InstantArticle
-     * @param string $subtitle The subtitle of the InstantArticle
+     * @param string|H2 $subtitle The subtitle of the InstantArticle
      */
     public function withSubTitle($subtitle)
     {
-        Type::enforce($subtitle, Type::STRING);
+        Type::enforce($subtitle, array(Type::STRING, H2::getClassName()));
         $this->subtitle = $subtitle;
 
         return $this;
@@ -307,19 +307,23 @@ class Header extends Element
         }
 
         if ($this->title) {
-            $title_element = $document->createElement('h1');
-            $title_fragment = $document->createDocumentFragment();
-            $title_fragment->appendXML($this->title);
-            $title_element->appendChild($title_fragment);
-            $element->appendChild($title_element);
+            if (Type::is($this->title, Type::STRING)) {
+                $title_element = $document->createElement('h1');
+                $title_element->appendChild($document->createTextNode($this->title));
+                $element->appendChild($title_element);
+            } else {
+                $element->appendChild($this->title->toDOMElement($document));
+            }
         }
 
         if ($this->subtitle) {
-            $sub_title_element = $document->createElement('h2');
-            $sub_title_fragment = $document->createDocumentFragment();
-            $sub_title_fragment->appendXML($this->subtitle);
-            $sub_title_element->appendChild($sub_title_fragment);
-            $element->appendChild($sub_title_element);
+            if (Type::is($this->title, Type::STRING)) {
+                $sub_title_element = $document->createElement('h2');
+                $sub_title_element->appendChild($document->createTextNode($this->subtitle));
+                $element->appendChild($sub_title_element);
+            } else {
+                $element->appendChild($this->subtitle->toDOMElement($document));
+            }
         }
 
         if ($this->published) {

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -62,7 +62,8 @@ abstract class TextContainer extends Element
         // Generate markup
         foreach ($this->textChildren as $content) {
             if (Type::is($content, Type::STRING)) {
-                $fragment->appendXML($content);
+                $text = $document->createTextNode($content);
+                $fragment->appendChild($text);
             } else {
                 $fragment->appendChild($content->toDOMElement($document));
             }

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -62,8 +62,7 @@ abstract class TextContainer extends Element
         // Generate markup
         foreach ($this->textChildren as $content) {
             if (Type::is($content, Type::STRING)) {
-                $text = $document->createTextNode($content);
-                $fragment->appendChild($text);
+                $fragment->appendXML($content);
             } else {
                 $fragment->appendChild($content->toDOMElement($document));
             }

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -8,6 +8,7 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
+use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H1;
 use Facebook\InstantArticles\Elements\Instantarticle;
@@ -20,7 +21,7 @@ class H1Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return array(Header::getClassName(), Caption::getClassName(), InstantArticle::getClassName());
     }
 
     public static function create()
@@ -56,7 +57,7 @@ class H1Rule extends ConfigurationSelectorRule
     public function apply($transformer, $context_element, $node)
     {
         $h1 = H1::create();
-        if (Type::is($context_element, Caption::getClassName())) {
+        if (Type::is($context_element, array(Header::getClassName(), Caption::getClassName()))) {
             $context_element->withTitle($h1);
         } elseif (Type::is($context_element, InstantArticle::getClassName())) {
             $context_element->addChild($h1);

--- a/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
@@ -8,6 +8,7 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
+use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H2;
 use Facebook\InstantArticles\Elements\Instantarticle;
@@ -20,7 +21,7 @@ class H2Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return array(Header::getClassName(), Caption::getClassName(), InstantArticle::getClassName());
     }
 
     public static function create()
@@ -52,7 +53,7 @@ class H2Rule extends ConfigurationSelectorRule
     public function apply($transformer, $context_element, $node)
     {
         $h2 = H2::create();
-        if (Type::is($context_element, Caption::getClassName())) {
+        if (Type::is($context_element, array(Header::getClassName(), Caption::getClassName()))) {
             $context_element->withSubTitle($h2);
         } elseif (Type::is($context_element, InstantArticle::getClassName())) {
             $context_element->addChild($h2);

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\H2;
 
 class HeaderSubTitleRule extends ConfigurationSelectorRule
 {
@@ -29,7 +30,7 @@ class HeaderSubTitleRule extends ConfigurationSelectorRule
 
     public function apply($transformer, $header, $h2)
     {
-        $header->withSubTitle($h2->textContent);
+        $header->withSubTitle($transformer->transform(H2::create(), $h2));
         return $header;
     }
 }

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\H1;
 
 class HeaderTitleRule extends ConfigurationSelectorRule
 {
@@ -29,7 +30,7 @@ class HeaderTitleRule extends ConfigurationSelectorRule
 
     public function apply($transformer, $header, $h1)
     {
-        $header->withTitle($h1->textContent);
+        $header->withTitle($transformer->transform(H1::create(), $h1));
         return $header;
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -144,4 +144,28 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $rendered);
     }
+
+    public function testHeaderWithTitles()
+    {
+        $header =
+            Header::create()
+                ->withTitle(
+                    H1::create()
+                        ->appendText('Big Top Title')
+                )
+                ->withSubTitle(
+                    H2::create()
+                        ->appendText('Smaller SubTitle')
+                );
+
+        $expected =
+            '<header>'.
+                '<h1>Big Top Title</h1>'.
+                '<h2>Smaller SubTitle</h2>'.
+            '</header>';
+
+        $rendered = $header->render();
+
+        $this->assertEquals($expected, $rendered);
+    }
 }

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.xml
@@ -15,8 +15,8 @@
           <img src="http://domain.com/image-header.png"/>
           <figcaption>Some amazing moment captured by Photographer</figcaption>
         </figure>
-        <h1>The article title</h1>
-        <h2>Sub Title</h2>
+        <h1>The article <b>title</b></h1>
+        <h2>Sub <b>Title</b></h2>
         <address><a>Author name</a></address>
       </header>
       <p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit. Sed eu arcu porta, ultrices massa ut, porttitor diam. Integer id auctor augue.</p>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple.html
@@ -4,8 +4,8 @@
     </head>
     <body>
         <div class="header">
-            <h1>The article title</h1>
-            <h2>Sub Title</h2>
+            <h1>The article <b>title</b></h1>
+            <h2>Sub <b>Title</b></h2>
             <span class="author">Author name</span>
             <div class="hero-image">
                 <img src="http://domain.com/image-header.png" />

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
@@ -15,8 +15,8 @@
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
           <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
         </figure>
-        <h1>Big Top Title</h1>
-        <h2>Smaller SubTitle</h2>
+        <h1>Big Top <b>Title</b></h1>
+        <h2>Smaller <b>SubTitle</b></h2>
         <time class="op-published" datetime="1984-08-14T19:30:00+00:00">August 14th, 7:30pm</time>
         <time class="op-modified" datetime="2016-02-10T10:00:00+00:00">February 10th, 10:00am</time>
         <address><a href="#" title="Title of author">Author Name</a>


### PR DESCRIPTION
This allows titles and subtitles to support markup such as `<em>`.