### PR TITLE
Fix: Simplify test bootstrapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,10 @@
         "psr-4": {
             "Facebook\\InstantArticles\\": ["src/Facebook/InstantArticles/"]
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Facebook\\InstantArticles\\": "tests/Facebook/InstantArticles/"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "27451258fbd10b198e79d95a28d003f6",
+    "hash": "68f2cdec57b57d94266ba0705fa47afc",
     "content-hash": "d1a7e51f731a8e2756648dca0a386d0a",
     "packages": [
         {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-    bootstrap="./tests/bootstrap.php"
+    bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="The project's test suite">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-$autoloader = require __DIR__ . '/../vendor/autoload.php';
-$autoloader->add('Facebook\\', __DIR__.'/../src');


### PR DESCRIPTION
This PR

* [x] simplifies the test bootstrapping

💁 Instead of manually adding the path to tests, it makes a lot more sense to define autoloading requirements for development environments in `composer.json`.