### PR TITLE
Fix: No need to specify an array of paths when there's one only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Facebook\\InstantArticles\\": ["src/Facebook/InstantArticles/"]
+            "Facebook\\InstantArticles\\": "src/Facebook/InstantArticles/"
         }
     }
 }


### PR DESCRIPTION
This PR

* [x] specifies a single path for PSR-4 autoloading instead of an array containing that path

Somewhat related to #36.