### PR TITLE
Fix: Limit range of accepted PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "homepage": "https://github.com/facebook/facebook-instant-articles-sdk-php/contributors"
     }],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "symfony/css-selector": "2.8.*",
         "facebook/php-sdk-v4": "~5.0",
         "apache/log4php": "2.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "27451258fbd10b198e79d95a28d003f6",
-    "content-hash": "d1a7e51f731a8e2756648dca0a386d0a",
+    "hash": "4eca806a6d37665e27804f77a9f20cec",
+    "content-hash": "ccec3d1767e6b90c43723a4672da4641",
     "packages": [
         {
             "name": "apache/log4php",
@@ -1107,7 +1107,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": "^5.4 || ^7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This PR

* [x] limits the range of acceptable PHP versions in `composer.json`

🙎 While PHP8 isn't out yet, it's not clear whether this package will be compatible with PHP8 or even PHP9000, right?