### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -11,7 +11,6 @@ namespace Facebook\InstantArticles\Client;
 
 use Facebook\Facebook;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\Authentication\AccessToken;
 use Facebook\InstantArticles\Validators\Type;
 
 class Client

--- a/src/Facebook/InstantArticles/Client/Helper.php
+++ b/src/Facebook/InstantArticles/Client/Helper.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Client;
 
 use Facebook\Facebook;
-use Facebook\Exceptions\FacebookResponseException;
 use Facebook\Exceptions\FacebookSDKException;
 use Facebook\Authentication\AccessToken;
 use Facebook\InstantArticles\Validators\Type;

--- a/src/Facebook/InstantArticles/Elements/Audible.php
+++ b/src/Facebook/InstantArticles/Elements/Audible.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Validators\Type;
 
 /**
  * Abstract class Audible

--- a/src/Facebook/InstantArticles/Elements/ListItem.php
+++ b/src/Facebook/InstantArticles/Elements/ListItem.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Validators\Type;
 
 /**
  * Class List that represents a simple HTML list

--- a/src/Facebook/InstantArticles/Transformer/Getters/AbstractGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/AbstractGetter.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Transformer\Getters;
 
-use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 /**
  * Class abstract for all getters.

--- a/src/Facebook/InstantArticles/Transformer/Getters/ChildrenGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ChildrenGetter.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Transformer\Getters;
 
-use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class ChildrenGetter extends ElementGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Getters/ExistsGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ExistsGetter.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class ExistsGetter extends StringGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Getters/IntegerGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/IntegerGetter.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class IntegerGetter extends StringGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingGetter.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class NextSiblingGetter extends StringGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Getters/StringGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/StringGetter.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class StringGetter extends ChildrenGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Getters/XpathGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/XpathGetter.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class XpathGetter extends ChildrenGetter
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
@@ -10,10 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Ad;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
-use Facebook\InstantArticles\Transformer\Getters\IntegerGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AdRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
@@ -10,10 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Analytics;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
-use Facebook\InstantArticles\Transformer\Getters\IntegerGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AnalyticsRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\TextContainer;
 use Facebook\InstantArticles\Elements\Anchor;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class AnchorRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/AudioRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AudioRule.php
@@ -10,11 +10,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Audio;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Audible;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AudioRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Author;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AuthorRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/BlockquoteRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/BlockquoteRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Blockquote;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class BlockquoteRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\TextContainer;
 use Facebook\InstantArticles\Elements\Bold;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class BoldRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Cite;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class CaptionCreditRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
@@ -15,10 +15,6 @@ use Facebook\InstantArticles\Elements\SocialEmbed;
 use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Caption;
-use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class CaptionRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
@@ -10,8 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Symfony\Component\CssSelector\CssSelectorConverter;
 use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Validators\Type;
 
 abstract class ConfigurationSelectorRule extends Rule

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\RelatedArticles;
 use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class FooterRelatedArticlesRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterRule.php
@@ -9,11 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class FooterRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/GeoTagRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GeoTagRule.php
@@ -12,8 +12,6 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\Map;
 use Facebook\InstantArticles\Elements\GeoTag;
-use Facebook\InstantArticles\Elements\Caption;
-use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class GeoTagRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -12,9 +12,6 @@ use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H1;
 use Facebook\InstantArticles\Elements\Instantarticle;
 use Facebook\InstantArticles\Validators\Type;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class H1Rule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
@@ -12,9 +12,6 @@ use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H2;
 use Facebook\InstantArticles\Elements\Instantarticle;
 use Facebook\InstantArticles\Validators\Type;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class H2Rule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
@@ -10,10 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Ad;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
-use Facebook\InstantArticles\Transformer\Getters\IntegerGetter;
 
 class HeaderAdRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
@@ -9,11 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class HeaderImageRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderKickerRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderKickerRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class HeaderKickerRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderRule.php
@@ -9,11 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Validators\Type;
-use Facebook\InstantArticles\Transformer\Transformer;
 
 class HeaderRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class HeaderSubTitleRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class HeaderTitleRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Element;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ElementGetter;
 
 class IgnoreRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
@@ -9,11 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class ImageRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
@@ -9,11 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class InstantArticleRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Interactive;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\TextContainer;
 use Facebook\InstantArticles\Elements\Italic;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class ItalicRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\TextContainer;
 use Facebook\InstantArticles\Elements\LineBreak;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ElementGetter;
 
 class LineBreakRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/ListElementRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ListElementRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\ListElement;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class ListElementRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/ListItemRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ListItemRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\ListElement;
 use Facebook\InstantArticles\Elements\ListItem;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class ListItemRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/MapRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/MapRule.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Map;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
 
 class MapRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/ParagraphFooterRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ParagraphFooterRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class ParagraphFooterRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/ParagraphRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ParagraphRule.php
@@ -10,11 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\ListItem;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
-use Facebook\InstantArticles\Validators\Type;
 
 class ParagraphRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/PassThroughRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/PassThroughRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Element;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class PassThroughRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/PullquoteCiteRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/PullquoteCiteRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Cite;
 use Facebook\InstantArticles\Elements\Pullquote;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class PullquoteCiteRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/PullquoteRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/PullquoteRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Pullquote;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class PullquoteRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\RelatedArticles;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class RelatedArticlesRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\RelatedItem;
 use Facebook\InstantArticles\Elements\RelatedArticles;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class RelatedItemRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
@@ -11,9 +11,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Slideshow;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class SlideshowImageRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Slideshow;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class SlideshowRule extends ConfigurationSelectorRule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\SocialEmbed;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/TextNodeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TextNodeRule.php
@@ -9,9 +9,6 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\TextContainer;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 
 class TextNodeRule extends Rule
 {

--- a/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
@@ -10,9 +10,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class TimeRule extends ConfigurationSelectorRule

--- a/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
@@ -11,11 +11,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 use Facebook\InstantArticles\Elements\Video;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Transformer\Getters\GetterFactory;
-use Facebook\InstantArticles\Transformer\Getters\StringGetter;
-use Facebook\InstantArticles\Transformer\Getters\ChildrenGetter;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class VideoRule extends ConfigurationSelectorRule

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -9,8 +9,6 @@
 namespace Facebook\InstantArticles\Client;
 
 use Facebook\Facebook;
-use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Paragraph;
 
 class HelperTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Ad;
 
 class AdTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Analytics;
 
 class AnalyticsTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/AudioTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AudioTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Audio;
 
 class AudioTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/AuthorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AuthorTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Author;
 
 class AuthorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Blockquote;
 
 class BlockquoteTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Caption;
 
 class CaptionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -8,10 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Cite;
-use Facebook\InstantArticles\Elements\Bold;
-use Facebook\InstantArticles\Elements\Italic;
-use Facebook\InstantArticles\Elements\Anchor;
 
 class CiteTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -8,9 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\RelatedArticles;
 
 class FooterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
+++ b/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\GeoTag;
-use Facebook\InstantArticles\Elements\Caption;
 
 class GeoTagTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -8,10 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\H1;
-use Facebook\InstantArticles\Elements\Bold;
-use Facebook\InstantArticles\Elements\Italic;
-use Facebook\InstantArticles\Elements\Anchor;
 
 class H1Test extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -8,10 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\H2;
-use Facebook\InstantArticles\Elements\Bold;
-use Facebook\InstantArticles\Elements\Italic;
-use Facebook\InstantArticles\Elements\Anchor;
 
 class H2Test extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -8,13 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Elements\Time;
-use Facebook\InstantArticles\Elements\Author;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
-
 class HeaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testCompleteHeader()

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -8,9 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Audio;
-use Facebook\InstantArticles\Elements\Caption;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -8,19 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Element;
-use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Elements\Time;
-use Facebook\InstantArticles\Elements\Author;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
-use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\SlideShow;
-use Facebook\InstantArticles\Elements\Analytics;
-use Facebook\InstantArticles\Elements\Ad;
-use Facebook\InstantArticles\Elements\Footer;
-
 class InstantArticleTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\ListElement;
 
 class ListElementTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -8,9 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Map;
-use Facebook\InstantArticles\Elements\GeoTag;
-use Facebook\InstantArticles\Elements\Caption;
 
 class MapTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
@@ -8,11 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\Bold;
-use Facebook\InstantArticles\Elements\LineBreak;
-use Facebook\InstantArticles\Elements\Italic;
-use Facebook\InstantArticles\Elements\Anchor;
 
 class ParagraphTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Pullquote;
 
 class PullquoteTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
+++ b/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\RelatedArticles;
-use Facebook\InstantArticles\Elements\RelatedItem;
 
 class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -8,10 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Slideshow;
-use Facebook\InstantArticles\Elements\Audio;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
 
 class SlideshowTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\SocialEmbed;
-use Facebook\InstantArticles\Elements\Caption;
 
 class SocialEmbedTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/TimeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/TimeTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Time;
 
 class TimeTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -13,8 +13,6 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\AnimatedGIF;
-use Facebook\InstantArticles\Elements\Element;
-use Facebook\InstantArticles\Validators\Type;
 
 /**
  *

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\InstantArticles\Elements\Video;
-use Facebook\InstantArticles\Elements\Caption;
 
 class VideoTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -8,29 +8,9 @@
  */
 namespace Facebook\InstantArticles\Transformer;
 
-use Facebook\InstantArticles\Elements\Element;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Elements\Time;
-use Facebook\InstantArticles\Elements\Author;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
-use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\SlideShow;
-use Facebook\InstantArticles\Elements\Analytics;
-use Facebook\InstantArticles\Elements\Ad;
-use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Elements\Bold;
 
-use Facebook\InstantArticles\Transformer\Rules\ParagraphRule;
-use Facebook\InstantArticles\Transformer\Rules\TextNodeRule;
-use Facebook\InstantArticles\Transformer\Rules\ItalicRule;
-use Facebook\InstantArticles\Transformer\Rules\PassThroughRule;
-use Facebook\InstantArticles\Transformer\Rules\BoldRule;
-use Facebook\InstantArticles\Transformer\Rules\ImageRule;
-use Facebook\InstantArticles\Transformer\Rules\AuthorRule;
 
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
-use Facebook\InstantArticles\Transformer\Rules\AuthorRule;
 
 class AuthorRuleTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
-use Facebook\InstantArticles\Transformer\Rules\PullquoteRule;
-use Facebook\InstantArticles\Transformer\Rules\PullquoteCiteRule;
 use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
 

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -8,29 +8,11 @@
  */
 namespace Facebook\InstantArticles\Transformer;
 
-use Facebook\InstantArticles\Elements\Element;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\Header;
-use Facebook\InstantArticles\Elements\Time;
-use Facebook\InstantArticles\Elements\Author;
-use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Caption;
-use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\Elements\SlideShow;
-use Facebook\InstantArticles\Elements\Analytics;
-use Facebook\InstantArticles\Elements\Ad;
-use Facebook\InstantArticles\Elements\Footer;
-use Facebook\InstantArticles\Elements\Bold;
 
 use Facebook\InstantArticles\Transformer\Rules\ParagraphRule;
-use Facebook\InstantArticles\Transformer\Rules\TextNodeRule;
 use Facebook\InstantArticles\Transformer\Rules\ItalicRule;
-use Facebook\InstantArticles\Transformer\Rules\PassThroughRule;
-use Facebook\InstantArticles\Transformer\Rules\BoldRule;
-use Facebook\InstantArticles\Transformer\Rules\ImageRule;
-use Facebook\InstantArticles\Transformer\Rules\AuthorRule;
 
-use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class TransformerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR

* [x] removes unused imports

Follows #17.

🙎 Of course, like one does, using [`fabpot/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and running

```
$ php-cs-fixer fix --rules=no_unused_imports src
$ php-cs-fixer fix --rules=no_unused_imports tests
```