### PR TITLE
Fix: Reference PHPUnit 4.8 schema in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="./tests/bootstrap.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    bootstrap="./tests/bootstrap.php"
+>
     <testsuites>
         <testsuite name="The project's test suite">
             <directory>./tests</directory>


### PR DESCRIPTION
This PR

* [x] references the PHPUnit 4.8 XML schema definition

💁 This is useful when making changes to `phpunit.xml`, as - when using a decent IDE - auto-completion is ensured.