### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -18,7 +18,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     private $article;
     private $facebook;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->facebook = $this->getMockBuilder('Facebook\Facebook')
             ->disableOriginalConstructor()

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -17,7 +17,7 @@ class HelperTest extends \PHPUnit_Framework_TestCase
     private $helper;
     private $facebook;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->facebook = $this->getMockBuilder('Facebook\Facebook')
             ->disableOriginalConstructor()

--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Ad;
 
 class AdTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Analytics;
 
 class AnalyticsTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/AudioTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AudioTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Audio;
 
 class AudioTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/AuthorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AuthorTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Author;
 
 class AuthorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Blockquote;
 
 class BlockquoteTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class CaptionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Anchor;
 
 class CiteTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -14,7 +14,7 @@ use Facebook\InstantArticles\Elements\RelatedArticles;
 
 class FooterTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
+++ b/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
@@ -13,7 +13,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class GeoTagTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Anchor;
 
 class H1Test extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Anchor;
 
 class H2Test extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -14,7 +14,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -27,7 +27,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
      * @var InstantArticle
      */
     private $article;
-    public function setUp()
+    protected function setUp()
     {
         date_default_timezone_set('UTC');
 

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -13,7 +13,7 @@ use Facebook\InstantArticles\Elements\Interactive;
 
 class InteractiveTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\ListElement;
 
 class ListElementTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -14,7 +14,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class MapTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
@@ -16,7 +16,7 @@ use Facebook\InstantArticles\Elements\Anchor;
 
 class ParagraphTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Elements\Pullquote;
 
 class PullquoteTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
+++ b/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
@@ -13,7 +13,7 @@ use Facebook\InstantArticles\Elements\RelatedItem;
 
 class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class SlideshowTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
@@ -13,7 +13,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class SocialEmbedTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Elements/TimeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/TimeTest.php
@@ -14,7 +14,7 @@ class TimeTest extends \PHPUnit_Framework_TestCase
 {
     private $timeDate;
 
-    public function setUp()
+    protected function setUp()
     {
         date_default_timezone_set('UTC');
         $this->timeDate = \DateTime::createFromFormat(

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -13,7 +13,7 @@ use Facebook\InstantArticles\Elements\Caption;
 
 class VideoTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -39,7 +39,7 @@ class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
      */
     private $article;
     private $input;
-    public function setUp()
+    protected function setUp()
     {
         \Logger::configure(
             array(

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Transformer\Rules\AuthorRule;
 
 class AuthorRuleTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 
 class PullquoteRuleTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         \Logger::configure(
             array(

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class TransformerTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         \Logger::configure(
             array(

--- a/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
@@ -15,7 +15,7 @@ class InvalidSelectorTest extends \PHPUnit_Framework_TestCase
 {
     private $properties;
 
-    public function setUp()
+    protected function setUp()
     {
 
     }


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` in tests from `public` to `protected`

💁 This is the visibility as defined on the parent; there's no need to increase it.

For reference, see [`PHPUnit_Framework_TestCase::setUp()`](https://github.com/sebastianbergmann/phpunit/blob/ed59ed9c4e8789b00e3a813384f7caa3f6ef1d49/src/Framework/TestCase.php#L2096-L2102).