### PR TITLE
Fix: Postion vs Position

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -188,15 +188,27 @@ class Caption extends FormattedText
     }
 
     /**
-    * The Text position that will be used.
-    *
-    * @see Caption::POSITION_ABOVE
-    * @see Caption::POSITION_BELOW
-    * @see Caption::POSITION_CENTER
-    *
-    * @param string position that will be used.
-    */
+     * @deprecated
+     *
+     * @param string $position
+     * @return $this
+     */
     public function withPostion($position)
+    {
+        return $this->withPosition($position);
+    }
+
+    /**
+     * The Text position that will be used.
+     *
+     * @see Caption::POSITION_ABOVE
+     * @see Caption::POSITION_BELOW
+     * @see Caption::POSITION_CENTER
+     *
+     * @param string $position that will be used.
+     * @return $this
+     */
+    public function withPosition($position)
     {
         Type::enforceWithin(
             $position,

--- a/src/Facebook/InstantArticles/Elements/Cite.php
+++ b/src/Facebook/InstantArticles/Elements/Cite.php
@@ -64,15 +64,27 @@ class Cite extends TextContainer
     }
 
     /**
-    * The Text position that will be used.
-    *
-    * @see Caption::POSITION_ABOVE
-    * @see Caption::POSITION_BELOW
-    * @see Caption::POSITION_CENTER
-    *
-    * @param string position that will be used.
-    */
+     * $deprecated
+     *
+     * @param string $position
+     * @return $this
+     */
     public function withPostion($position)
+    {
+        return $this->withPosition($position);
+    }
+
+    /**
+     * The Text position that will be used.
+     *
+     * @see Caption::POSITION_ABOVE
+     * @see Caption::POSITION_BELOW
+     * @see Caption::POSITION_CENTER
+     *
+     * @param string $position that will be used.
+     * @return $this
+     */
+    public function withPosition($position)
     {
         Type::enforceWithin(
             $position,

--- a/src/Facebook/InstantArticles/Elements/H1.php
+++ b/src/Facebook/InstantArticles/Elements/H1.php
@@ -64,15 +64,27 @@ class H1 extends TextContainer
     }
 
     /**
-    * The Text position that will be used.
-    *
-    * @see Caption::POSITION_ABOVE
-    * @see Caption::POSITION_BELOW
-    * @see Caption::POSITION_CENTER
-    *
-    * @param string position that will be used.
-    */
+     * @deprecated
+     *
+     * @param string $position
+     * @return $this
+     */
     public function withPostion($position)
+    {
+        return $this->withPosition($position);
+    }
+
+    /**
+     * The Text position that will be used.
+     *
+     * @see Caption::POSITION_ABOVE
+     * @see Caption::POSITION_BELOW
+     * @see Caption::POSITION_CENTER
+     *
+     * @param string $position that will be used.
+     * @return $this
+     */
+    public function withPosition($position)
     {
         Type::enforceWithin(
             $position,

--- a/src/Facebook/InstantArticles/Elements/H2.php
+++ b/src/Facebook/InstantArticles/Elements/H2.php
@@ -65,15 +65,27 @@ class H2 extends TextContainer
     }
 
     /**
-    * The Text position that will be used.
-    *
-    * @see Caption::POSITION_ABOVE
-    * @see Caption::POSITION_BELOW
-    * @see Caption::POSITION_CENTER
-    *
-    * @param string position that will be used.
-    */
+     * @deprecated
+     *
+     * @param string $position
+     * @return $this
+     */
     public function withPostion($position)
+    {
+        return $this->withPosition($position);
+    }
+
+    /**
+     * The Text position that will be used.
+     *
+     * @see Caption::POSITION_ABOVE
+     * @see Caption::POSITION_BELOW
+     * @see Caption::POSITION_CENTER
+     *
+     * @param string $position
+     * @return $this
+     */
+    public function withPosition($position)
     {
         Type::enforceWithin(
             $position,

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
@@ -50,13 +50,13 @@ class CaptionCreditRule extends ConfigurationSelectorRule
         $caption->withCredit($cite);
 
         if ($this->getProperty(Caption::POSITION_BELOW, $node)) {
-            $cite->withPostion(Caption::POSITION_BELOW);
+            $cite->withPosition(Caption::POSITION_BELOW);
         }
         if ($this->getProperty(Caption::POSITION_CENTER, $node)) {
-            $cite->withPostion(Caption::POSITION_CENTER);
+            $cite->withPosition(Caption::POSITION_CENTER);
         }
         if ($this->getProperty(Caption::POSITION_ABOVE, $node)) {
-            $cite->withPostion(Caption::POSITION_ABOVE);
+            $cite->withPosition(Caption::POSITION_ABOVE);
         }
 
         if ($this->getProperty(Caption::ALIGN_LEFT, $node)) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
@@ -71,13 +71,13 @@ class CaptionRule extends ConfigurationSelectorRule
         $container_of_caption->withCaption($caption);
 
         if ($this->getProperty(Caption::POSITION_BELOW, $node)) {
-            $caption->withPostion(Caption::POSITION_BELOW);
+            $caption->withPosition(Caption::POSITION_BELOW);
         }
         if ($this->getProperty(Caption::POSITION_CENTER, $node)) {
-            $caption->withPostion(Caption::POSITION_CENTER);
+            $caption->withPosition(Caption::POSITION_CENTER);
         }
         if ($this->getProperty(Caption::POSITION_ABOVE, $node)) {
-            $caption->withPostion(Caption::POSITION_ABOVE);
+            $caption->withPosition(Caption::POSITION_ABOVE);
         }
 
         if ($this->getProperty(Caption::ALIGN_LEFT, $node)) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -60,13 +60,13 @@ class H1Rule extends ConfigurationSelectorRule
         }
 
         if ($this->getProperty(Caption::POSITION_BELOW, $node)) {
-            $h1->withPostion(Caption::POSITION_BELOW);
+            $h1->withPosition(Caption::POSITION_BELOW);
         }
         if ($this->getProperty(Caption::POSITION_CENTER, $node)) {
-            $h1->withPostion(Caption::POSITION_CENTER);
+            $h1->withPosition(Caption::POSITION_CENTER);
         }
         if ($this->getProperty(Caption::POSITION_ABOVE, $node)) {
-            $h1->withPostion(Caption::POSITION_ABOVE);
+            $h1->withPosition(Caption::POSITION_ABOVE);
         }
 
         if ($this->getProperty(Caption::ALIGN_LEFT, $node)) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
@@ -56,13 +56,13 @@ class H2Rule extends ConfigurationSelectorRule
         }
 
         if ($this->getProperty(Caption::POSITION_BELOW, $node)) {
-            $h2->withPostion(Caption::POSITION_BELOW);
+            $h2->withPosition(Caption::POSITION_BELOW);
         }
         if ($this->getProperty(Caption::POSITION_CENTER, $node)) {
-            $h2->withPostion(Caption::POSITION_CENTER);
+            $h2->withPosition(Caption::POSITION_CENTER);
         }
         if ($this->getProperty(Caption::POSITION_ABOVE, $node)) {
-            $h2->withPostion(Caption::POSITION_ABOVE);
+            $h2->withPosition(Caption::POSITION_ABOVE);
         }
 
         if ($this->getProperty(Caption::ALIGN_LEFT, $node)) {

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -69,7 +69,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
         $caption =
             Caption::create()
                 ->appendText('Caption Title')
-                ->withPostion(Caption::POSITION_BELOW);
+                ->withPosition(Caption::POSITION_BELOW);
 
         $expected =
             '<figcaption class="op-vertical-below">'.
@@ -118,7 +118,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             Caption::create()
                 ->appendText('Caption Title')
                 ->withFontsize(Caption::SIZE_LARGE)
-                ->withPostion(Caption::POSITION_BELOW)
+                ->withPosition(Caption::POSITION_BELOW)
                 ->withTextAlignment(Caption::ALIGN_LEFT);
 
         $expected =

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -35,7 +35,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
         $cite =
             Cite::create()
                 ->appendText('Citation simple text.')
-                ->withPostion(Caption::POSITION_ABOVE);
+                ->withPosition(Caption::POSITION_ABOVE);
 
         $expected =
             '<cite class="op-vertical-above">'.
@@ -67,7 +67,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
         $cite =
             Cite::create()
                 ->appendText('Citation simple text.')
-                ->withPostion(Caption::POSITION_ABOVE)
+                ->withPosition(Caption::POSITION_ABOVE)
                 ->withTextAlignment(Caption::ALIGN_LEFT);
 
         $expected =

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -35,7 +35,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $h1 =
             H1::create()
                 ->appendText('Title simple text.')
-                ->withPostion(Caption::POSITION_ABOVE);
+                ->withPosition(Caption::POSITION_ABOVE);
 
         $expected =
             '<h1 class="op-vertical-above">'.
@@ -67,7 +67,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $h1 =
             H1::create()
                 ->appendText('Title simple text.')
-                ->withPostion(Caption::POSITION_ABOVE)
+                ->withPosition(Caption::POSITION_ABOVE)
                 ->withTextAlignment(Caption::ALIGN_LEFT);
 
         $expected =

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -35,7 +35,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
         $h2 =
             H2::create()
                 ->appendText('Sub title simple text.')
-                ->withPostion(Caption::POSITION_ABOVE);
+                ->withPosition(Caption::POSITION_ABOVE);
 
         $expected =
             '<h2 class="op-vertical-above">'.
@@ -67,7 +67,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
         $h2 =
             H2::create()
                 ->appendText('Sub title simple text.')
-                ->withPostion(Caption::POSITION_ABOVE)
+                ->withPosition(Caption::POSITION_ABOVE)
                 ->withTextAlignment(Caption::ALIGN_LEFT);
 
         $expected =

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -59,7 +59,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
                     Caption::create()
                         ->withTitle('Title of Image caption')
                         ->withCredit('Some caption to the image')
-                        ->withPostion(Caption::POSITION_BELOW)
+                        ->withPosition(Caption::POSITION_BELOW)
                 );
 
         $expected =

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -71,7 +71,7 @@ class MapTest extends \PHPUnit_Framework_TestCase
                     Caption::create()
                         ->withTitle('Title of Image caption')
                         ->withCredit('Some caption to the image')
-                        ->withPostion(Caption::POSITION_BELOW)
+                        ->withPosition(Caption::POSITION_BELOW)
                 );
 
         $expected =


### PR DESCRIPTION
This PR

* [x] deprecates misspelled methods `withPostion()` and delegates to one that is correctly spelled instead