### PR TITLE
Fix: Use appropriate annotation for return types

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Author.php
+++ b/src/Facebook/InstantArticles/Elements/Author.php
@@ -119,7 +119,7 @@ class Author extends Element
     }
 
     /**
-     * @param string author link url profile
+     * @return string author link url profile
      */
     public function getUrl()
     {
@@ -127,7 +127,7 @@ class Author extends Element
     }
 
     /**
-     * @param string author name
+     * @return string author name
      */
     public function getName()
     {
@@ -135,7 +135,7 @@ class Author extends Element
     }
 
     /**
-     * @param string author small introduction biography
+     * @return string author small introduction biography
      */
     public function getDescription()
     {
@@ -143,7 +143,7 @@ class Author extends Element
     }
 
     /**
-     * @param string author short text to define its contribution/role
+     * @return string author short text to define its contribution/role
      */
     public function getRoleContribution()
     {

--- a/src/Facebook/InstantArticles/Elements/RelatedArticles.php
+++ b/src/Facebook/InstantArticles/Elements/RelatedArticles.php
@@ -90,7 +90,7 @@ class RelatedArticles extends Element
     }
 
     /**
-     * @param string the name of related articles block
+     * @return string the name of related articles block
      */
     public function getTitle()
     {


### PR DESCRIPTION
This PR

* [x] uses `@return` instead of `@param` for annotating return types in accessors