### PR TITLE
Refactor and optimize transformer up to 10x faster

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
@@ -54,10 +54,47 @@ abstract class ConfigurationSelectorRule extends Rule
 
     public function matchesNode($node)
     {
-        if ($this->selector === 'html' && $node->nodeName === 'html') {
+        // Only matches DOMElements (ignore text and comments)
+        if (!Type::is($node, 'DOMElement')) {
+            return false;
+        }
+
+        // Handles selector = tag
+        if ($node->nodeName === $this->selector) {
             return true;
         }
 
+        // Handles selector = .class
+        if (preg_match('/^\.[a-zA-Z][a-zA-Z0-9-]*$/', $this->selector) === 1) {
+
+            // Tries every class
+            $classNames = explode(' ', $node->getAttribute('class'));
+            foreach ($classNames as $className) {
+                if ('.' . $className === $this->selector) {
+                    return true;
+                }
+            }
+
+            // No match!
+            return false;
+        }
+
+        // Handles selector = tag.class
+        if (preg_match('/^[a-zA-Z][a-zA-Z0-9-]*(\.[a-zA-Z][a-zA-Z0-9-]*)?$/', $this->selector) === 1) {
+
+            // Tries every class
+            $classNames = explode(' ', $node->getAttribute('class'));
+            foreach ($classNames as $className) {
+                if ($node->nodeName . '.' . $className === $this->selector) {
+                    return true;
+                }
+            }
+
+            // No match!
+            return false;
+        }
+
+        // Proceed with the more expensive XPath query
         $document = $node->ownerDocument;
         $domXPath = new \DOMXPath($document);
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
@@ -16,6 +16,24 @@ abstract class Rule
 
         $matches_context = $this->matchesContext($context);
         $matches_node = $this->matchesNode($node);
+        if ($matches_context && $matches_node) {
+            $log->debug('context class: '.get_class($context));
+            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
+            $log->debug('node name: <'.$node->nodeName.' />');
+            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
+            $log->debug('rule: '.get_class($this));
+            $log->debug('-------');
+            return true;
+        }
+        if ($node->nodeName === 'img') {
+            $log->debug('context class: '.get_class($context));
+            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
+            $log->debug('node name: <'.$node->nodeName.' />');
+            $log->debug('node: '.$node->ownerDocument->saveXML($node).' />');
+            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
+            $log->debug('rule: '.get_class($this));
+            $log->debug('-------');
+        }
         return false;
     }
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
@@ -16,24 +16,6 @@ abstract class Rule
 
         $matches_context = $this->matchesContext($context);
         $matches_node = $this->matchesNode($node);
-        if ($matches_context && $matches_node) {
-            $log->debug('context class: '.get_class($context));
-            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
-            $log->debug('node name: <'.$node->nodeName.' />');
-            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
-            $log->debug('rule: '.get_class($this));
-            $log->debug('-------');
-            return true;
-        }
-        if ($node->nodeName === 'img') {
-            $log->debug('context class: '.get_class($context));
-            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
-            $log->debug('node name: <'.$node->nodeName.' />');
-            $log->debug('node: '.$node->ownerDocument->saveXML($node).' />');
-            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
-            $log->debug('rule: '.get_class($this));
-            $log->debug('-------');
-        }
         return false;
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -87,7 +87,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $rule2 = new ItalicRule();
         $transformer->addRule($rule1);
         $transformer->addRule($rule2);
-        $this->assertEquals(array($rule2, $rule1), $transformer->getRules());
+        $this->assertEquals(array($rule1, $rule2), $transformer->getRules());
     }
 
     public function testTransformerSetRules()


### PR DESCRIPTION
I've changed the internals of the transformer so it performs over 10x faster on the complete example. Changes were commented at the code.

Also removed some arbitrary logging that are leftover from our internal testing.

The outside interface was kept compatible, but I've fixed `getRules()` to return the rules in the order they were inserted, making more sense as now `getRules()` will return exactly the value set using `setRules()`.