### PR TITLE
Fix: Use willReturn()

### DIFF
--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -87,7 +87,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
           ->expects($this->once())
           ->method('getArticleIDFromCanonicalURL')
           ->with($canonicalURL)
-          ->will($this->returnValue($articleID));;
+          ->willReturn($articleID);
 
         $this->facebook
           ->expects($this->once())
@@ -158,21 +158,21 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getField')
             ->with($this->equalTo('id'))
-            ->will($this->returnValue($expectedArticleID));
+            ->willReturn($expectedArticleID);
         $graphNodeMock
             ->expects($this->once())
             ->method('getField')
             ->with($this->equalTo('instant_article'))
-            ->will($this->returnValue($instantArticleMock));
+            ->willReturn($instantArticleMock);
         $serverResponseMock
             ->expects($this->once())
             ->method('getGraphNode')
-            ->will($this->returnValue($graphNodeMock));
+            ->willReturn($graphNodeMock);
         $this->facebook
             ->expects($this->once())
             ->method('get')
             ->with($this->equalTo('?id='.$canonicalURL.'&fields=instant_article'))
-            ->will($this->returnValue($serverResponseMock));
+            ->willReturn($serverResponseMock);
 
         $articleID = $this->client->getArticleIDFromCanonicalURL($canonicalURL);
         $this->assertEquals($expectedArticleID, $articleID);
@@ -197,16 +197,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getField')
             ->with($this->equalTo('instant_article'))
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serverResponseMock
             ->expects($this->once())
             ->method('getGraphNode')
-            ->will($this->returnValue($graphNodeMock));
+            ->willReturn($graphNodeMock);
         $this->facebook
             ->expects($this->once())
             ->method('get')
             ->with($this->equalTo('?id='.$canonicalURL.'&fields=instant_article'))
-            ->will($this->returnValue($serverResponseMock));
+            ->willReturn($serverResponseMock);
 
         $articleID = $this->client->getArticleIDFromCanonicalURL($canonicalURL);
         $this->assertEquals($expectedArticleID, $articleID);
@@ -229,7 +229,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getField')
             ->with($this->equalTo('most_recent_import_status'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 "status" => "success",
                 "errors" => array(
                     array(
@@ -249,17 +249,17 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                         "message" => "Test info"
                     )
                 )
-            )));
+            ));
 
         $serverResponseMock
             ->expects($this->once())
             ->method('getGraphNode')
-            ->will($this->returnValue($graphNodeMock));
+            ->willReturn($graphNodeMock);
         $this->facebook
             ->expects($this->once())
             ->method('get')
             ->with($this->equalTo($articleID . '?fields=most_recent_import_status'))
-            ->will($this->returnValue($serverResponseMock));
+            ->willReturn($serverResponseMock);
 
         $status = $this->client->getLastSubmissionStatus($articleID);
         $this->assertEquals($status->getStatus(), InstantArticleStatus::SUCCESS);

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -36,7 +36,7 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $accessToken
             ->expects($this->once())
             ->method('isLongLived')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->facebook
             ->expects($this->once())
             ->method('setDefaultAccessToken')
@@ -49,13 +49,13 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $response
             ->expects($this->once())
             ->method('getGraphEdge')
-            ->will($this->returnValue($pagesAndTokens));
+            ->willReturn($pagesAndTokens);
 
         $this->facebook
             ->expects($this->once())
             ->method('get')
             ->with('/me/accounts?fields=name,id,access_token,supports_instant_articles')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $pagesAndTokensReturned = $this->helper->getPagesAndTokens($accessToken);
         $this->assertEquals($pagesAndTokensReturned, $pagesAndTokens);


### PR DESCRIPTION
This PR

* [x] uses `willReturn($value)` instead of `will($this->returnValue($value))` when setting up test doubles