### PR TITLE
Fix: Remove unused import referencing undefined class

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -8,8 +8,6 @@
  */
 namespace Facebook\InstantArticles\Transformer\Getters;
 
-use Facebook\InstantArticles\Transformer\Validators\Type;
-
 class GetterFactory
 {
     const TYPE_STRING_GETTER = 'string';


### PR DESCRIPTION
This PR

* [x] removes an unused import referencing an undefined class