### PR TITLE
Enhancement: Cache dependencies installed with Composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,15 @@ php:
   - 7.0
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - travis_retry composer self-update
 
 install:
-  - travis_retry composer install --no-interaction
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with Composer between Travis builds

💁 For reference, see https://docs.travis-ci.com/user/caching/#Arbitrary-directories.

