### PR TITLE
Fix: Undefined class Facebook\InstantArticles\Client\Exception

### DIFF
--- a/src/Facebook/InstantArticles/Client/ClientException.php
+++ b/src/Facebook/InstantArticles/Client/ClientException.php
@@ -9,6 +9,6 @@
 
 namespace Facebook\InstantArticles\Client;
 
-class ClientException extends Exception
+class ClientException extends \Exception
 {
 }

--- a/tests/Facebook/InstantArticles/Client/ClientExceptionTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientExceptionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Facebook\InstantArticles\Client;
+
+class ClientExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExtendsException()
+    {
+        $exception = new ClientException();
+
+        $this->assertInstanceOf('Exception', $exception);
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that `ClientException` extends `Exception`
* [x] references `Exception` from root namespace