### PR TITLE
Enhancement: Use a bit of color when running tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    colors="true"
 >
     <testsuites>
         <testsuite name="The project's test suite">


### PR DESCRIPTION
This PR

* [x] enables the `color` option when running tests

### Before

![screen shot 2016-04-20 at 17 42 22](https://cloud.githubusercontent.com/assets/605483/14680925/5c2cc404-071f-11e6-83f1-ca6d3609aaed.png)

### After

![screen shot 2016-04-20 at 17 42 34](https://cloud.githubusercontent.com/assets/605483/14680932/60bdbd98-071f-11e6-982f-cead47341acb.png)
