### PR TITLE
Fix: Authenticate with GitHub API to avoid public rate limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 
 before_install:
   - travis_retry composer self-update
+  - composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist


### PR DESCRIPTION
This PR

* [x] authenticates with the GitHub API before installing dependencies

💁 This speeds up the builds when the public GitHub API rate limit is exceeded.

❗ This requires an actual `GITHUB_TOKEN` set as an environment variable at 

* https://travis-ci.org/facebook/facebook-instant-articles-sdk-php/settings

ideally with **Display value in build log** set to **OFF** (this is the default):

![screen shot 2016-04-20 at 17 49 26](https://cloud.githubusercontent.com/assets/605483/14681199/6c203fde-0720-11e6-96b8-ddba8fa0e376.png)
