### PR TITLE
Enhancement: Validate composer.json and composer.lock on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 
 before_install:
   - travis_retry composer self-update
+  - composer validate
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist


### PR DESCRIPTION
This PR

* [x] validates `composer.json` and `composer.lock` on Travis

💁 Running 

```
$ composer validate
```

yields

```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "Facebook Platform" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

Worth fixing?

For reference, see https://getcomposer.org/doc/03-cli.md#validate.