### PR TITLE
Fix Composer license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["facebook", "sdk", "instant", "articles"],
     "type": "library",
     "homepage": "https://github.com/facebook/facebook-instant-articles-sdk-php",
-    "license": "Facebook Platform",
+    "license": "proprietary",
     "authors": [{
         "name": "Facebook",
         "homepage": "https://github.com/facebook/facebook-instant-articles-sdk-php/contributors"


### PR DESCRIPTION
"Facebook Platform" is not a proper [SPDX License Identifier](https://spdx.org/licenses/). Let's follow the [Composer schema](https://getcomposer.org/doc/04-schema.md#license) and set to "proprietary". This will remove the warning when running `composer validate` (as mentioned in #67).