### PR TITLE
Fix: Disable xdebug to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - travis_retry composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN


### PR DESCRIPTION
This PR

* [x] disables xdebug to further speed up the build

🙆 Unless we want to collect coverage, we don't need it, right?