### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -111,7 +111,7 @@ class Client
     public function removeArticle($canonicalURL)
     {
         if (!$canonicalURL) {
-            return InstantArticleStatus::notFound(array('$canonicalURL param not passed to ' . __FUNCTION__ . '.'));
+            return InstantArticleStatus::notFound(['$canonicalURL param not passed to ' . __FUNCTION__ . '.']);
         }
 
         Type::enforce($canonicalURL, Type::STRING);
@@ -120,7 +120,7 @@ class Client
             $this->facebook->delete($articleID);
             return InstantArticleStatus::success();
         }
-        return InstantArticleStatus::notFound(array('An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.'));
+        return InstantArticleStatus::notFound(['An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.']);
     }
 
     /**
@@ -163,7 +163,7 @@ class Client
         $response = $this->facebook->get($articleID . '?fields=most_recent_import_status');
         $articleStatus = $response->getGraphNode()->getField('most_recent_import_status');
 
-        $messages = array();
+        $messages = [];
         if (isset($articleStatus['errors'])) {
             foreach ($articleStatus['errors'] as $error) {
                 $messages[] = ServerMessage::fromLevel($error['level'], $error['message']);

--- a/src/Facebook/InstantArticles/Client/InstantArticleStatus.php
+++ b/src/Facebook/InstantArticles/Client/InstantArticleStatus.php
@@ -21,7 +21,7 @@ class InstantArticleStatus
     const FAILED = 'failed';
     const UNKNOWN = 'unknown';
 
-    private $messages = array();
+    private $messages = [];
 
     /**
      * Instantiates a new InstantArticleStatus object.
@@ -31,17 +31,17 @@ class InstantArticleStatus
      *
      * @throws FacebookSDKException
      */
-    public function __construct($status, $messages = array())
+    public function __construct($status, $messages = [])
     {
         Type::enforceWithin(
             $status,
-            array(
+            [
                 self::SUCCESS,
                 self::NOT_FOUND,
                 self::IN_PROGRESS,
                 self::FAILED,
                 self::UNKNOWN
-            )
+            ]
         );
         Type::enforceArrayOf(
             $messages,
@@ -64,12 +64,12 @@ class InstantArticleStatus
         $status = strtolower($status);
         $validStatus = Type::isWithin(
             $status,
-            array(
+            [
                 self::SUCCESS,
                 self::NOT_FOUND,
                 self::IN_PROGRESS,
                 self::FAILED
-            )
+            ]
         );
         if ($validStatus) {
             return new self($status, $messages);
@@ -80,27 +80,27 @@ class InstantArticleStatus
         }
     }
 
-    public static function success($messages = array())
+    public static function success($messages = [])
     {
         return new self(self::SUCCESS, $messages);
     }
 
-    public static function notFound($messages = array())
+    public static function notFound($messages = [])
     {
         return new self(self::NOT_FOUND, $messages);
     }
 
-    public static function inProgress($messages = array())
+    public static function inProgress($messages = [])
     {
         return new self(self::IN_PROGRESS, $messages);
     }
 
-    public static function failed($messages = array())
+    public static function failed($messages = [])
     {
         return new self(self::FAILED, $messages);
     }
 
-    public static function unknown($messages = array())
+    public static function unknown($messages = [])
     {
         return new self(self::UNKNOWN, $messages);
     }

--- a/src/Facebook/InstantArticles/Client/ServerMessage.php
+++ b/src/Facebook/InstantArticles/Client/ServerMessage.php
@@ -24,12 +24,12 @@ class ServerMessage
     {
         Type::enforceWithin(
             $level,
-            array(
+            [
                 self::FATAL,
                 self::ERROR,
                 self::WARNING,
                 self::INFO
-            )
+            ]
         );
         Type::enforce(
             $message,
@@ -52,12 +52,12 @@ class ServerMessage
         $level = strtolower($level);
         $validLevel = Type::isWithin(
             $level,
-            array(
+            [
                 self::FATAL,
                 self::ERROR,
                 self::WARNING,
                 self::INFO
-            )
+            ]
         );
         if ($validLevel) {
             return new self($level, $message);

--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -97,7 +97,7 @@ class Caption extends FormattedText
      */
     public function withTitle($title)
     {
-        Type::enforce($title, array(Type::STRING, H1::getClassName()));
+        Type::enforce($title, [Type::STRING, H1::getClassName()]);
 
         if (Type::is($title, Type::STRING)) {
             $title = H1::create()->appendText($title);
@@ -114,7 +114,7 @@ class Caption extends FormattedText
      */
     public function withSubTitle($sub_title)
     {
-        Type::enforce($sub_title, array(Type::STRING, H2::getClassName()));
+        Type::enforce($sub_title, [Type::STRING, H2::getClassName()]);
         if (Type::is($sub_title, Type::STRING)) {
             $sub_title = H2::create()->appendText($sub_title);
         }
@@ -130,7 +130,7 @@ class Caption extends FormattedText
      */
     public function withCredit($credit)
     {
-        Type::enforce($credit, array(Type::STRING, Cite::getClassName()));
+        Type::enforce($credit, [Type::STRING, Cite::getClassName()]);
         if (Type::is($credit, Type::STRING)) {
             $credit = Cite::create()->appendText($credit);
         }
@@ -152,11 +152,11 @@ class Caption extends FormattedText
     {
         Type::enforceWithin(
             $font_size,
-            array(
+            [
                 Caption::SIZE_XLARGE,
                 Caption::SIZE_LARGE,
                 Caption::SIZE_MEDIUM
-            )
+            ]
         );
         $this->fontSize = $font_size;
 
@@ -176,11 +176,11 @@ class Caption extends FormattedText
     {
         Type::enforceWithin(
             $text_alignment,
-            array(
+            [
                 Caption::ALIGN_RIGHT,
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER
-            )
+            ]
         );
         $this->textAlignment = $text_alignment;
 
@@ -212,11 +212,11 @@ class Caption extends FormattedText
     {
         Type::enforceWithin(
             $position,
-            array(
+            [
                 Caption::POSITION_ABOVE,
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER
-            )
+            ]
         );
         $this->position = $position;
 
@@ -317,7 +317,7 @@ class Caption extends FormattedText
 
      // Formatting markup
         if ($this->textAlignment || $this->fontSize || $this->position) {
-            $classes = array();
+            $classes = [];
             if ($this->textAlignment) {
                 $classes[] = $this->textAlignment;
             }

--- a/src/Facebook/InstantArticles/Elements/Cite.php
+++ b/src/Facebook/InstantArticles/Elements/Cite.php
@@ -52,11 +52,11 @@ class Cite extends TextContainer
     {
         Type::enforceWithin(
             $text_alignment,
-            array(
+            [
                 Caption::ALIGN_RIGHT,
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER
-            )
+            ]
         );
         $this->textAlignment = $text_alignment;
 
@@ -88,11 +88,11 @@ class Cite extends TextContainer
     {
         Type::enforceWithin(
             $position,
-            array(
+            [
                 Caption::POSITION_ABOVE,
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER
-            )
+            ]
         );
         $this->position = $position;
 
@@ -111,7 +111,7 @@ class Cite extends TextContainer
         }
         $cite = $document->createElement('cite');
 
-        $classes = array();
+        $classes = [];
         if ($this->position) {
             $classes[] = $this->position;
         }

--- a/src/Facebook/InstantArticles/Elements/Footer.php
+++ b/src/Facebook/InstantArticles/Elements/Footer.php
@@ -32,7 +32,7 @@ class Footer extends Element
     /**
      * @var string|Paragraph[] The text content of the credits
      */
-    private $credits = array();
+    private $credits = [];
 
     /**
      * @var string Copyright information of the article
@@ -60,7 +60,7 @@ class Footer extends Element
      */
     public function withCredits($credits)
     {
-        Type::enforce($credits, array(Type::ARRAY_TYPE, Paragraph::getClassName(), Type::STRING));
+        Type::enforce($credits, [Type::ARRAY_TYPE, Paragraph::getClassName(), Type::STRING]);
         $this->credits = $credits;
 
         return $this;

--- a/src/Facebook/InstantArticles/Elements/H1.php
+++ b/src/Facebook/InstantArticles/Elements/H1.php
@@ -52,11 +52,11 @@ class H1 extends TextContainer
     {
         Type::enforceWithin(
             $text_alignment,
-            array(
+            [
                 Caption::ALIGN_RIGHT,
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER
-            )
+            ]
         );
         $this->textAlignment = $text_alignment;
 
@@ -88,11 +88,11 @@ class H1 extends TextContainer
     {
         Type::enforceWithin(
             $position,
-            array(
+            [
                 Caption::POSITION_ABOVE,
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER
-            )
+            ]
         );
         $this->position = $position;
 
@@ -111,7 +111,7 @@ class H1 extends TextContainer
         }
         $h1 = $document->createElement('h1');
 
-        $classes = array();
+        $classes = [];
         if ($this->position) {
             $classes[] = $this->position;
         }

--- a/src/Facebook/InstantArticles/Elements/H2.php
+++ b/src/Facebook/InstantArticles/Elements/H2.php
@@ -53,11 +53,11 @@ class H2 extends TextContainer
     {
         Type::enforceWithin(
             $text_alignment,
-            array(
+            [
                 Caption::ALIGN_RIGHT,
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER
-            )
+            ]
         );
         $this->textAlignment = $text_alignment;
 
@@ -89,11 +89,11 @@ class H2 extends TextContainer
     {
         Type::enforceWithin(
             $position,
-            array(
+            [
                 Caption::POSITION_ABOVE,
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER
-            )
+            ]
         );
         $this->position = $position;
 
@@ -112,7 +112,7 @@ class H2 extends TextContainer
         }
         $h2 = $document->createElement('h2');
 
-        $classes = array();
+        $classes = [];
         if ($this->position) {
             $classes[] = $this->position;
         }

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -58,7 +58,7 @@ class Header extends Element
     /**
      * @var Author[] Authors of the article.
      */
-    private $authors = array();
+    private $authors = [];
 
     /**
      * @var Time of publishing for the article
@@ -79,7 +79,7 @@ class Header extends Element
     /**
      * @var Ad[] Ads of the article.
      */
-    private $ads = array();
+    private $ads = [];
 
     private function __construct()
     {
@@ -96,7 +96,7 @@ class Header extends Element
      */
     public function withCover($cover)
     {
-        Type::enforce($cover, array(Image::getClassName(), Video::getClassName()));
+        Type::enforce($cover, [Image::getClassName(), Video::getClassName()]);
         $this->cover = $cover;
 
         return $this;

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -133,12 +133,12 @@ class Image extends Audible
     {
         Type::enforceWithin(
             $presentation,
-            array(
+            [
                 Image::ASPECT_FIT,
                 Image::ASPECT_FIT_ONLY,
                 Image::FULLSCREEN,
                 Image::NON_INTERACTIVE
-            )
+            ]
         );
         $this->presentation = $presentation;
 
@@ -192,7 +192,7 @@ class Image extends Audible
      */
     public function withGeoTag($geo_tag)
     {
-        Type::enforce($geo_tag, array(Type::STRING, GeoTag::getClassName()));
+        Type::enforce($geo_tag, [Type::STRING, GeoTag::getClassName()]);
         if (Type::is($geo_tag, Type::STRING)) {
             $this->geoTag = GeoTag::create()->withScript($geo_tag);
         } elseif (Type::is($geo_tag, GeoTag::getClassName())) {

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -38,7 +38,7 @@ class InstantArticle extends Element
     /**
      * The meta properties that are used on <head>
      */
-    private $metaProperties = array();
+    private $metaProperties = [];
 
     /**
      * @var string The canonical URL for the Instant Article
@@ -78,7 +78,7 @@ class InstantArticle extends Element
     /**
      * @var Element[] of all elements an article can have.
      */
-    private $children = array();
+    private $children = [];
 
     /**
      * Factory method
@@ -190,7 +190,7 @@ class InstantArticle extends Element
     {
         Type::enforce(
             $child,
-            array(
+            [
                 Ad::getClassName(),
                 Analytics::getClassName(),
                 AnimatedGIF::getClassName(),
@@ -208,7 +208,7 @@ class InstantArticle extends Element
                 Slideshow::getClassName(),
                 SocialEmbed::getClassName(),
                 Video::getClassName()
-            )
+            ]
         );
         $this->children[] = $child;
 

--- a/src/Facebook/InstantArticles/Elements/Interactive.php
+++ b/src/Facebook/InstantArticles/Elements/Interactive.php
@@ -112,10 +112,10 @@ class Interactive extends Element
     {
         Type::enforceWithin(
             $width,
-            array(
+            [
                 Interactive::NO_MARGIN,
                 Interactive::COLUMN_WIDTH
-            )
+            ]
         );
         $this->width = $width;
 

--- a/src/Facebook/InstantArticles/Elements/ListElement.php
+++ b/src/Facebook/InstantArticles/Elements/ListElement.php
@@ -37,7 +37,7 @@ class ListElement extends Element
     /**
      * @var ListItem[] Items of the list
      */
-    private $items = array();
+    private $items = [];
 
     /**
      * Private constructor.
@@ -78,7 +78,7 @@ class ListElement extends Element
      */
     public function addItem($new_item)
     {
-        Type::enforce($new_item, array(ListItem::getClassName(), Type::STRING));
+        Type::enforce($new_item, [ListItem::getClassName(), Type::STRING]);
         if (Type::is($new_item, Type::STRING)) {
             $new_item = ListItem::create()->appendText($new_item);
         }
@@ -94,7 +94,7 @@ class ListElement extends Element
      */
     public function withItems($new_items)
     {
-        Type::enforceArrayOf($new_items, array(ListItem::getClassName(), Type::STRING));
+        Type::enforceArrayOf($new_items, [ListItem::getClassName(), Type::STRING]);
         foreach ($new_items as $new_item) {
             $this->addItem($new_item);
         }

--- a/src/Facebook/InstantArticles/Elements/Pullquote.php
+++ b/src/Facebook/InstantArticles/Elements/Pullquote.php
@@ -49,7 +49,7 @@ class Pullquote extends TextContainer
      */
     public function withAttribution($attribution)
     {
-        Type::enforce($attribution, array(Type::STRING, Cite::getClassName()));
+        Type::enforce($attribution, [Type::STRING, Cite::getClassName()]);
         if (Type::is($attribution, Type::STRING)) {
             $this->attribution = Cite::create()->appendText($attribution);
         } else {

--- a/src/Facebook/InstantArticles/Elements/RelatedArticles.php
+++ b/src/Facebook/InstantArticles/Elements/RelatedArticles.php
@@ -32,7 +32,7 @@ class RelatedArticles extends Element
     /**
      * @var RelatedItem[] The related Articles
      */
-    private $items = array();
+    private $items = [];
 
     /**
      * @var string The title of the Related Articles content

--- a/src/Facebook/InstantArticles/Elements/Slideshow.php
+++ b/src/Facebook/InstantArticles/Elements/Slideshow.php
@@ -39,7 +39,7 @@ class Slideshow extends Audible
     /**
      * @var Image[] the images hosted on web that will be shown on the slideshow
      */
-    private $article_images = array();
+    private $article_images = [];
 
     /**
      * @var string The json geotag content inside the script geotag

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -23,7 +23,7 @@ abstract class TextContainer extends Element
     /**
      * @var array The content is a list of strings and FormattingElements
      */
-    private $textChildren = array();
+    private $textChildren = [];
 
     /**
      * Adds content to the formatted text.
@@ -32,7 +32,7 @@ abstract class TextContainer extends Element
      */
     public function appendText($child)
     {
-        Type::enforce($child, array(Type::STRING, FormattedText::getClassName(), TextContainer::getClassName()));
+        Type::enforce($child, [Type::STRING, FormattedText::getClassName(), TextContainer::getClassName()]);
         $this->textChildren[] = $child;
 
         return $this;

--- a/src/Facebook/InstantArticles/Elements/Time.php
+++ b/src/Facebook/InstantArticles/Elements/Time.php
@@ -90,10 +90,10 @@ class Time extends Element
     {
         Type::enforceWithin(
             $type,
-            array(
+            [
                 Time::MODIFIED,
                 Time::PUBLISHED
-            )
+            ]
         );
         $this->type = $type;
 

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -163,12 +163,12 @@ class Video extends Element
     {
         Type::enforceWithin(
             $presentation,
-            array(
+            [
                 Video::ASPECT_FIT,
                 Video::ASPECT_FIT_ONLY,
                 Video::FULLSCREEN,
                 Video::NON_INTERACTIVE
-            )
+            ]
         );
         $this->presentation = $presentation;
 
@@ -294,7 +294,7 @@ class Video extends Element
      */
     public function withGeoTag($geoTag)
     {
-        Type::enforce($geoTag, array(Type::STRING, GeoTag::getClassName()));
+        Type::enforce($geoTag, [Type::STRING, GeoTag::getClassName()]);
         if (Type::is($geoTag, Type::STRING)) {
             $this->geoTag = GeoTag::create()->withScript($geoTag);
         } elseif (Type::is($geoTag, GeoTag::getClassName())) {

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -37,7 +37,7 @@ class GetterFactory
      */
     public static function create($getter_configuration)
     {
-        $GETTERS = array(
+        $GETTERS = [
             self::TYPE_STRING_GETTER => StringGetter::getClassName(),
             self::TYPE_INTEGER_GETTER => IntegerGetter::getClassName(),
             self::TYPE_CHILDREN_GETTER => ChildrenGetter::getClassName(),
@@ -45,7 +45,7 @@ class GetterFactory
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),
             self::TYPE_XPATH_GETTER => XpathGetter::getClassName()
-        );
+        ];
 
         $class = $getter_configuration['type'];
         if (array_key_exists($class, $GETTERS)) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
@@ -41,12 +41,12 @@ class AdRule extends ConfigurationSelectorRule
         $ad_rule->withSelector($configuration['selector']);
 
         $ad_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_AD_URL,
                 self::PROPERTY_AD_HEIGHT_URL,
                 self::PROPERTY_AD_WIDTH_URL,
                 self::PROPERTY_AD_EMBED_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
@@ -39,10 +39,10 @@ class AnalyticsRule extends ConfigurationSelectorRule
         $analytics_rule->withSelector($configuration['selector']);
 
         $analytics_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_TRACKER_URL,
                 self::PROPERTY_TRACKER_EMBED_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
@@ -37,10 +37,10 @@ class AnchorRule extends ConfigurationSelectorRule
         $anchor_rule->withSelector($configuration['selector']);
         $properties = $configuration['properties'];
         $anchor_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_ANCHOR_HREF,
                 self::PROPERTY_ANCHOR_REL
-            ),
+            ],
             $properties
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/AudioRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AudioRule.php
@@ -36,12 +36,12 @@ class AudioRule extends ConfigurationSelectorRule
         $audio_rule->withSelector($configuration['selector']);
 
         $audio_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_AUDIO_URL,
                 self::PROPERTY_AUDIO_TITLE,
                 self::PROPERTY_AUDIO_AUTOPLAY,
                 self::PROPERTY_AUDIO_MUTED
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
@@ -36,12 +36,12 @@ class AuthorRule extends ConfigurationSelectorRule
         $author_rule->withSelector($configuration['selector']);
         $properties = $configuration['properties'];
         $author_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_AUTHOR_URL,
                 self::PROPERTY_AUTHOR_NAME,
                 self::PROPERTY_AUTHOR_DESCRIPTION,
                 self::PROPERTY_AUTHOR_ROLE_CONTRIBUTION
-            ),
+            ],
             $properties
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionCreditRule.php
@@ -29,7 +29,7 @@ class CaptionCreditRule extends ConfigurationSelectorRule
         $cite_rule->withSelector($configuration['selector']);
 
         $cite_rule->withProperties(
-            array(
+            [
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER,
                 Caption::POSITION_ABOVE,
@@ -37,7 +37,7 @@ class CaptionCreditRule extends ConfigurationSelectorRule
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER,
                 Caption::ALIGN_RIGHT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
@@ -23,14 +23,14 @@ class CaptionRule extends ConfigurationSelectorRule
     public function getContextClass()
     {
         return
-            array(
+            [
                 Map::getClassName(),
                 Image::getClassName(),
                 Interactive::getClassName(),
                 Slideshow::getClassName(),
                 SocialEmbed::getClassName(),
                 Video::getClassName()
-            );
+            ];
     }
 
     public static function create()
@@ -44,7 +44,7 @@ class CaptionRule extends ConfigurationSelectorRule
         $caption_rule->withSelector($configuration['selector']);
 
         $caption_rule->withProperties(
-            array(
+            [
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER,
                 Caption::POSITION_ABOVE,
@@ -58,7 +58,7 @@ class CaptionRule extends ConfigurationSelectorRule
                 Caption::SIZE_XLARGE,
 
                 self::PROPERTY_DEFAULT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Validators\Type;
 abstract class ConfigurationSelectorRule extends Rule
 {
     protected $selector;
-    protected $properties = array();
+    protected $properties = [];
 
     public function withSelector($selector)
     {

--- a/src/Facebook/InstantArticles/Transformer/Rules/GeoTagRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GeoTagRule.php
@@ -20,7 +20,7 @@ class GeoTagRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return array(Image::getClassName(), Video::getClassName(), Map::getClassName());
+        return [Image::getClassName(), Video::getClassName(), Map::getClassName()];
     }
 
     public static function create()

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -17,7 +17,7 @@ class H1Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return [Caption::getClassName(), InstantArticle::getClassName()];
     }
 
     public static function create()
@@ -31,7 +31,7 @@ class H1Rule extends ConfigurationSelectorRule
         $h1_rule->withSelector($configuration['selector']);
 
         $h1_rule->withProperties(
-            array(
+            [
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER,
                 Caption::POSITION_ABOVE,
@@ -43,7 +43,7 @@ class H1Rule extends ConfigurationSelectorRule
                 Caption::SIZE_MEDIUM,
                 Caption::SIZE_LARGE,
                 Caption::SIZE_XLARGE
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
@@ -17,7 +17,7 @@ class H2Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return [Caption::getClassName(), InstantArticle::getClassName()];
     }
 
     public static function create()
@@ -31,7 +31,7 @@ class H2Rule extends ConfigurationSelectorRule
         $h2_rule->withSelector($configuration['selector']);
 
         $h2_rule->withProperties(
-            array(
+            [
                 Caption::POSITION_BELOW,
                 Caption::POSITION_CENTER,
                 Caption::POSITION_ABOVE,
@@ -39,7 +39,7 @@ class H2Rule extends ConfigurationSelectorRule
                 Caption::ALIGN_LEFT,
                 Caption::ALIGN_CENTER,
                 Caption::ALIGN_RIGHT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
@@ -34,12 +34,12 @@ class HeaderAdRule extends ConfigurationSelectorRule
         $ad_rule->withSelector($configuration['selector']);
 
         $ad_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_AD_URL,
                 self::PROPERTY_AD_HEIGHT_URL,
                 self::PROPERTY_AD_WIDTH_URL,
                 self::PROPERTY_AD_EMBED_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
@@ -36,9 +36,9 @@ class HeaderImageRule extends ConfigurationSelectorRule
         $image_rule->withSelector($configuration['selector']);
 
         $image_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_IMAGE_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
@@ -38,11 +38,11 @@ class ImageRule extends ConfigurationSelectorRule
         $image_rule->withSelector($configuration['selector']);
 
         $image_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_IMAGE_URL,
                 self::PROPERTY_LIKE,
                 self::PROPERTY_COMMENTS
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
@@ -39,12 +39,12 @@ class InstantArticleRule extends ConfigurationSelectorRule
         $canonical_rule->withSelector($configuration['selector']);
 
         $canonical_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_CANONICAL,
                 self::PROPERTY_CHARSET,
                 self::PROPERTY_MARKUP_VERSION,
                 self::PROPERTY_AUTO_AD_PLACEMENT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
@@ -36,13 +36,13 @@ class InteractiveRule extends ConfigurationSelectorRule
         $interactive_rule->withSelector($configuration['selector']);
 
         $interactive_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_IFRAME,
                 self::PROPERTY_URL,
                 self::PROPERTY_WIDTH_NO_MARGIN,
                 self::PROPERTY_WIDTH_COLUMN_WIDTH,
                 self::PROPERTY_HEIGHT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
@@ -37,10 +37,10 @@ class RelatedItemRule extends ConfigurationSelectorRule
         $related_item_rule->withSelector($configuration['selector']);
 
         $related_item_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_SPONSORED,
                 self::PROPERTY_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
@@ -39,11 +39,11 @@ class SlideshowImageRule extends ConfigurationSelectorRule
         $image_rule->withSelector($configuration['selector']);
 
         $image_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_IMAGE_URL,
                 self::PROPERTY_CAPTION_TITLE,
                 self::PROPERTY_CAPTION_CREDIT
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
@@ -33,10 +33,10 @@ class SocialEmbedRule extends ConfigurationSelectorRule
         $social_embed_rule->withSelector($configuration['selector']);
 
         $social_embed_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_IFRAME,
                 self::PROPERTY_URL
-            ),
+            ],
             $configuration
         );
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
@@ -79,7 +79,7 @@ class VideoRule extends ConfigurationSelectorRule
         }
 
         $video_rule->withProperties(
-            array(
+            [
                 self::PROPERTY_VIDEO_URL,
                 self::PROPERTY_VIDEO_TYPE,
 
@@ -93,7 +93,7 @@ class VideoRule extends ConfigurationSelectorRule
 
                 self::PROPERTY_LIKE,
                 self::PROPERTY_COMMENTS
-            ),
+            ],
             $configuration
         );
         return $video_rule;

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -15,13 +15,13 @@ use Facebook\InstantArticles\Validators\Type;
 
 class Transformer
 {
-    private $rules = array();
-    private $warnings = array();
+    private $rules = [];
+    private $warnings = [];
     private $ruleCount = 0;
 
     public $suppress_warnings = false;
 
-    private static $allClassTypes = array();
+    private static $allClassTypes = [];
 
     /**
      * Gets all types a given class is, including itself, parent classes and interfaces.
@@ -37,7 +37,7 @@ class Transformer
 
         $classParents = class_parents($className, true);
         $classInterfaces = class_implements($className, true);
-        $classNames = array($className);
+        $classNames = [$className];
         if ($classParents) {
             $classNames = array_merge($classNames, $classParents);
         }
@@ -62,12 +62,12 @@ class Transformer
 
         // Handles multiple contexts
         if (!is_array($contexts)) {
-            $contexts = array($contexts);
+            $contexts = [$contexts];
         }
 
         foreach ($contexts as $context) {
             if (!isset($this->rules[$context])) {
-                $this->rules[$context] = array();
+                $this->rules[$context] = [];
             }
             $this->rules[$context][$this->ruleCount++] = $rule;
         }
@@ -105,7 +105,7 @@ class Transformer
                 $contextClassNames = self::getAllClassTypes($context->getClassName());
 
                 // Look for rules applying to any of them as context
-                $matchingContextRules = array();
+                $matchingContextRules = [];
                 foreach ($contextClassNames as $contextClassName) {
                     if (isset($this->rules[$contextClassName])) {
                         // Use array union (+) instead of merge to preserve
@@ -177,7 +177,7 @@ class Transformer
      */
     public function resetRules()
     {
-        $this->rules = array();
+        $this->rules = [];
         $this->ruleCount = 0;
     }
 
@@ -190,7 +190,7 @@ class Transformer
     {
         // Do not expose internal map, just a simple array
         // to keep the interface backwards compatible.
-        $flatten_rules = array();
+        $flatten_rules = [];
         foreach ($this->rules as $ruleset) {
             foreach ($ruleset as $priority => $rule) {
                 $flatten_rules[$priority] = $rule;

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -76,12 +76,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // Use a mocked client with stubbed getArticleIDFromCanonicalURL().
         $this->client = $this->getMockBuilder('Facebook\InstantArticles\Client\Client')
-          ->setMethods(array('getArticleIDFromCanonicalURL'))
-          ->setConstructorArgs(array(
+          ->setMethods(['getArticleIDFromCanonicalURL'])
+          ->setConstructorArgs([
             $this->facebook,
             "PAGE_ID",
             true // developmentMode
-          ))->getMock();
+          ])->getMock();
 
         $this->client
           ->expects($this->once())
@@ -229,27 +229,27 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getField')
             ->with($this->equalTo('most_recent_import_status'))
-            ->willReturn(array(
+            ->willReturn([
                 "status" => "success",
-                "errors" => array(
-                    array(
+                "errors" => [
+                    [
                         "level" => "warning",
                         "message" => "Test warning"
-                    ),
-                    array(
+                    ],
+                    [
                         "level" => "fatal",
                         "message" => "Test fatal"
-                    ),
-                    array(
+                    ],
+                    [
                         "level" => "error",
                         "message" => "Test error"
-                    ),
-                    array(
+                    ],
+                    [
                         "level" => "info",
                         "message" => "Test info"
-                    )
-                )
-            ));
+                    ]
+                ]
+            ]);
 
         $serverResponseMock
             ->expects($this->once())

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -27,7 +27,7 @@ class HelperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPagesAndTokes()
     {
-        $pagesAndTokens = array('page' => 'token');
+        $pagesAndTokens = ['page' => 'token'];
 
         $accessToken =
             $this->getMockBuilder('Facebook\Authentication\AccessToken')

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -38,7 +38,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
     {
         $list =
             ListElement::createOrdered()
-                ->withItems(array('Item 1', 'Item 2', 'Item 3'));
+                ->withItems(['Item 1', 'Item 2', 'Item 3']);
 
         $expected =
             '<ol>'.
@@ -74,7 +74,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
     {
         $list =
             ListElement::createUnordered()
-                ->withItems(array('Item 1', 'Item 2', 'Item 3'));
+                ->withItems(['Item 1', 'Item 2', 'Item 3']);
 
         $expected =
             '<ul>'.

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -26,13 +26,13 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsType()
     {
-        $result = Type::is(Caption::create(), array(Caption::getClassName()));
+        $result = Type::is(Caption::create(), [Caption::getClassName()]);
         $this->assertTrue($result);
     }
 
     public function testIsTypeWithArray()
     {
-        $result = Type::is(array(1, 2, 3), Type::ARRAY_TYPE);
+        $result = Type::is([1, 2, 3], Type::ARRAY_TYPE);
         $this->assertTrue($result);
     }
 
@@ -40,12 +40,12 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             Caption::create(),
-            array(
+            [
                 Caption::getClassName(),
                 InstantArticle::getClassName(),
                 Video::getClassName(),
                 Image::getClassName()
-            )
+            ]
         );
         $this->assertTrue($result);
     }
@@ -54,9 +54,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             Caption::create(),
-            array(
+            [
                 Image::getClassName()
-            )
+            ]
         );
         $this->assertFalse($result);
     }
@@ -66,9 +66,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         try {
             $result = Type::enforce(
                 Caption::create(),
-                array(
+                [
                     Image::getClassName()
-                )
+                ]
             );
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
@@ -81,7 +81,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             Caption::create(),
-            array()
+            []
         );
         $this->assertFalse($result);
     }
@@ -91,7 +91,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         try {
             $result = Type::enforce(
                 Caption::create(),
-                array()
+                []
             );
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
@@ -104,11 +104,11 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             Caption::create(),
-            array(
+            [
                 InstantArticle::getClassName(),
                 Video::getClassName(),
                 Image::getClassName()
-            )
+            ]
         );
         $this->assertFalse($result);
     }
@@ -118,11 +118,11 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         try {
             $result = Type::enforce(
                 Caption::create(),
-                array(
+                [
                     InstantArticle::getClassName(),
                     Video::getClassName(),
                     Image::getClassName()
-                )
+                ]
             );
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
@@ -135,9 +135,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             AnimatedGIF::create(),
-            array(
+            [
                 Image::getClassName()
-            )
+            ]
         );
         $this->assertTrue($result);
     }
@@ -146,9 +146,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result = Type::is(
             AnimatedGIF::create(),
-            array(
+            [
                 Video::getClassName()
-            )
+            ]
         );
         $this->assertFalse($result);
     }
@@ -158,9 +158,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         try {
             $result = Type::enforce(
                 AnimatedGIF::create(),
-                array(
+                [
                     Video::getClassName()
-                )
+                ]
             );
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
@@ -194,7 +194,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsArrayOfString()
     {
-        $result = Type::isArrayOf(array('1', '2'), Type::STRING);
+        $result = Type::isArrayOf(['1', '2'], Type::STRING);
         $this->assertTrue($result);
     }
 
@@ -202,7 +202,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result =
             Type::isArrayOf(
-                array(Image::create(), Image::create()),
+                [Image::create(), Image::create()],
                 Image::getClassName()
             );
         $this->assertTrue($result);
@@ -212,8 +212,8 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result =
             Type::isArrayOf(
-                array(Image::create(), Video::create()),
-                array(Image::getClassName(), Video::getClassName())
+                [Image::create(), Video::create()],
+                [Image::getClassName(), Video::getClassName()]
             );
         $this->assertTrue($result);
     }
@@ -221,7 +221,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     public function testIsArrayInInheritance()
     {
         $result = Type::isArrayOf(
-            array(Image::create(), AnimatedGIF::create()),
+            [Image::create(), AnimatedGIF::create()],
             Image::getClassName()
         );
         $this->assertTrue($result);
@@ -231,7 +231,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $result =
             Type::isArrayOf(
-                array(Image::create(), Video::create()),
+                [Image::create(), Video::create()],
                 Image::getClassName()
             );
         $this->assertFalse($result);
@@ -242,7 +242,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         try {
             $result =
                 Type::enforceArrayOf(
-                    array(Image::create(), Video::create()),
+                    [Image::create(), Video::create()],
                     Image::getClassName()
                 );
             $this->fail('Should throw exception');
@@ -257,38 +257,38 @@ class TypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testArraySize()
     {
-        $result = Type::isArraySize(array(1,2,3), 3);
+        $result = Type::isArraySize([1,2,3], 3);
         $this->assertTrue($result);
     }
 
     public function testArrayNotSize()
     {
-        $result = Type::isArraySize(array(1,2,3), 2);
+        $result = Type::isArraySize([1,2,3], 2);
         $this->assertFalse($result);
     }
 
     public function testArrayMinSizeExact()
     {
-        $result = Type::isArraySizeGreaterThan(array(1,2,3), 3);
+        $result = Type::isArraySizeGreaterThan([1,2,3], 3);
         $this->assertTrue($result);
     }
 
     public function testArrayMinSizeMore()
     {
-        $result = Type::isArraySizeGreaterThan(array(1,2,3), 2);
+        $result = Type::isArraySizeGreaterThan([1,2,3], 2);
         $this->assertTrue($result);
     }
 
     public function testArrayMinSizeFew()
     {
-        $result = Type::isArraySizeGreaterThan(array(1,2,3), 4);
+        $result = Type::isArraySizeGreaterThan([1,2,3], 4);
         $this->assertFalse($result);
     }
 
     public function testEnforceArrayMinSizeException()
     {
         try {
-            $result = Type::enforceArraySizeGreaterThan(array(1,2,3), 4);
+            $result = Type::enforceArraySizeGreaterThan([1,2,3], 4);
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
@@ -297,26 +297,26 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
     public function testArrayMaxSizeExact()
     {
-        $result = Type::isArraySizeLowerThan(array(1,2,3), 3);
+        $result = Type::isArraySizeLowerThan([1,2,3], 3);
         $this->assertTrue($result);
     }
 
     public function testArrayMaxSizeFew()
     {
-        $result = Type::isArraySizeLowerThan(array(1,2,3), 4);
+        $result = Type::isArraySizeLowerThan([1,2,3], 4);
         $this->assertTrue($result);
     }
 
     public function testArrayMaxSizeMore()
     {
-        $result = Type::isArraySizeLowerThan(array(1,2,3), 2);
+        $result = Type::isArraySizeLowerThan([1,2,3], 2);
         $this->assertFalse($result);
     }
 
     public function testEnforceArrayMaxSizeException()
     {
         try {
-            $result = Type::enforceArraySizeLowerThan(array(1,2,3), 2);
+            $result = Type::enforceArraySizeLowerThan([1,2,3], 2);
             $this->fail('Should throw exception');
         } catch (\Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
@@ -325,7 +325,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsWithinTrueString()
     {
-        $result = Type::isWithin('x', array('x', 'y', 'z'));
+        $result = Type::isWithin('x', ['x', 'y', 'z']);
         $this->assertTrue($result);
     }
 
@@ -333,13 +333,13 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     {
         $image = Image::create();
         $video = Video::create();
-        $result = Type::isWithin($image, array($image, $video, 'z'));
+        $result = Type::isWithin($image, [$image, $video, 'z']);
         $this->assertTrue($result);
     }
 
     public function testIsWithinFalse()
     {
-        $result = Type::isWithin('a', array('x', 'y', 'z'));
+        $result = Type::isWithin('a', ['x', 'y', 'z']);
         $this->assertFalse($result);
     }
 
@@ -348,20 +348,20 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $image = Image::create();
         $video = Video::create();
         $anotherImg = Image::create();
-        $result = Type::isWithin($image, array($anotherImg, $video, 'z'));
+        $result = Type::isWithin($image, [$anotherImg, $video, 'z']);
         $this->assertFalse($result);
     }
 
     public function testEnforceWithinTrueString()
     {
-        $result = Type::enforceWithin('x', array('x', 'y', 'z'));
+        $result = Type::enforceWithin('x', ['x', 'y', 'z']);
         $this->assertTrue($result);
     }
 
     public function testEnforceWithinExceptionString()
     {
         try {
-            $result = Type::enforceWithin('a', array('x', 'y', 'z'));
+            $result = Type::enforceWithin('a', ['x', 'y', 'z']);
             $this->fail('Should trhow exception');
         } catch (\Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -22,20 +22,20 @@ class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         \Logger::configure(
-            array(
-                'rootLogger' => array(
-                    'appenders' => array('facebook-instantarticles-transformer')
-                ),
-                'appenders' => array(
-                    'facebook-instantarticles-transformer' => array(
+            [
+                'rootLogger' => [
+                    'appenders' => ['facebook-instantarticles-transformer']
+                ],
+                'appenders' => [
+                    'facebook-instantarticles-transformer' => [
                         'class' => 'LoggerAppenderConsole',
                         'threshold' => 'INFO',
-                        'layout' => array(
+                        'layout' => [
                             'class' => 'LoggerLayoutSimple'
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -18,21 +18,21 @@ class AuthorRuleTest extends \PHPUnit_Framework_TestCase
     public function testCreateFromProperties()
     {
         $author_rule = AuthorRule::createFrom(
-            array(
+            [
                 "class" => "Facebook\\InstantArticles\\Transformer\\Rules\\AuthorRule",
                 "selector" => "div.post-content > p > em",
-                "properties" => array(
-                    "author.url" => array(
+                "properties" => [
+                    "author.url" => [
                         "type" => "string",
                         "selector" => "a",
                         "attribute" => "href"
-                    ),
-                    "author.description" => array(
+                    ],
+                    "author.description" => [
                         "type" => "string",
                         "selector" => "#text:nth-child(2)"
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
         $this->assertEquals(get_class($author_rule), AuthorRule::getClassName());
     }
@@ -43,18 +43,18 @@ class AuthorRuleTest extends \PHPUnit_Framework_TestCase
             ->withSelector("div.post-content > p > em")
             ->withProperty(
                 AuthorRule::PROPERTY_AUTHOR_URL,
-                array(
+                [
                     "type" => "string",
                     "selector" => "a",
                     "attribute" => "href"
-                )
+                ]
             )
             ->withProperty(
                 AuthorRule::PROPERTY_AUTHOR_NAME,
-                array(
+                [
                     "type" => "string",
                     "selector" => "span"
-                )
+                ]
             );
         $this->assertEquals(get_class($author_rule), AuthorRule::getClassName());
     }

--- a/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
@@ -16,20 +16,20 @@ class PullquoteRuleTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         \Logger::configure(
-            array(
-                'rootLogger' => array(
-                    'appenders' => array('facebook-instantarticles-transformer')
-                ),
-                'appenders' => array(
-                    'facebook-instantarticles-transformer' => array(
+            [
+                'rootLogger' => [
+                    'appenders' => ['facebook-instantarticles-transformer']
+                ],
+                'appenders' => [
+                    'facebook-instantarticles-transformer' => [
                         'class' => 'LoggerAppenderConsole',
                         'threshold' => 'INFO',
-                        'layout' => array(
+                        'layout' => [
                             'class' => 'LoggerLayoutSimple'
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -19,20 +19,20 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         \Logger::configure(
-            array(
-                'rootLogger' => array(
-                    'appenders' => array('facebook-instantarticles-transformer')
-                ),
-                'appenders' => array(
-                    'facebook-instantarticles-transformer' => array(
+            [
+                'rootLogger' => [
+                    'appenders' => ['facebook-instantarticles-transformer']
+                ],
+                'appenders' => [
+                    'facebook-instantarticles-transformer' => [
                         'class' => 'LoggerAppenderConsole',
                         'threshold' => 'INFO',
-                        'layout' => array(
+                        'layout' => [
                             'class' => 'LoggerLayoutSimple'
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -69,7 +69,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $rule2 = new ItalicRule();
         $transformer->addRule($rule1);
         $transformer->addRule($rule2);
-        $this->assertEquals(array($rule1, $rule2), $transformer->getRules());
+        $this->assertEquals([$rule1, $rule2], $transformer->getRules());
     }
 
     public function testTransformerSetRules()
@@ -77,8 +77,8 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $transformer = new Transformer();
         $rule1 = new ParagraphRule();
         $rule2 = new ItalicRule();
-        $transformer->setRules(array($rule1, $rule2));
-        $this->assertEquals(array($rule1, $rule2), $transformer->getRules());
+        $transformer->setRules([$rule1, $rule2]);
+        $this->assertEquals([$rule1, $rule2], $transformer->getRules());
     }
 
     public function testTransformerResetRules()
@@ -89,6 +89,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $transformer->addRule($rule1);
         $transformer->addRule($rule2);
         $transformer->resetRules();
-        $this->assertEquals(array(), $transformer->getRules());
+        $this->assertEquals([], $transformer->getRules());
     }
 }


### PR DESCRIPTION
This PR

* [x] uses short array syntax

Follows #39.

🙎 Of course, like one does, using [`fabpot/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and running

```
$ php-cs-fixer fix --rules=short_array_syntax src
$ php-cs-fixer fix --rules=short_array_syntax tests
```