### PR TITLE
Fix: Remove empty setUp() methods

### DIFF
--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class AdTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $ad =

--- a/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class AnalyticsTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $analytics =

--- a/tests/Facebook/InstantArticles/Elements/AudioTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AudioTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class AudioTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $audio =

--- a/tests/Facebook/InstantArticles/Elements/AuthorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AuthorTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class AuthorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderAuthorWithFB()
     {
         $author =

--- a/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class BlockquoteTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $blockquote =

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class CaptionTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $caption =

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class CiteTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $cite =

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class FooterTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $footer =

--- a/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
+++ b/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class GeoTagTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderWithGeotag()
     {
         $script =

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class H1Test extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $h1 =

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class H2Test extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $h2 =

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $image =

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Interactive;
 
 class InteractiveTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $interactive =

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class ListElementTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderOrdered()
     {
         $list =

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class MapTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderWithGeotag()
     {
         $script =

--- a/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class ParagraphTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $paragraph =

--- a/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class PullquoteTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $analytics =

--- a/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
+++ b/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $element =

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class SlideshowTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $slideshow =

--- a/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class SocialEmbedTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $social_embed =

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Elements;
 
 class VideoTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testRenderBasic()
     {
         $video =

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -11,10 +11,6 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 class AuthorRuleTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-    }
-
     public function testCreateFromProperties()
     {
         $author_rule = AuthorRule::createFrom(

--- a/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
@@ -15,11 +15,6 @@ class InvalidSelectorTest extends \PHPUnit_Framework_TestCase
 {
     private $properties;
 
-    protected function setUp()
-    {
-
-    }
-
     public function testInvalidSelectorToString()
     {
 


### PR DESCRIPTION
This PR

* [x] removes empty `setUp()` methods from tests

💁 No need to override the parent, which is empty, right?