### PR TITLE
Fix: Remove unused private fields

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Anchor.php
+++ b/src/Facebook/InstantArticles/Elements/Anchor.php
@@ -25,11 +25,6 @@ class Anchor extends FormattedText
      */
     private $rel;
 
-    /**
-     * @var string content.
-     */
-    private $content;
-
     private function __construct()
     {
     }

--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -62,11 +62,6 @@ class Caption extends FormattedText
     private $credit;
 
     /**
-     * @var string A free text not contained in the tags
-     */
-    private $text;
-
-    /**
      * @var string text Size. Values: "op-medium"|"op-large"|"op-extra-large"
      */
     private $fontSize;

--- a/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
@@ -19,8 +19,6 @@ class AdRule extends ConfigurationSelectorRule
     const PROPERTY_AD_WIDTH_URL = 'ad.width';
     const PROPERTY_AD_EMBED_URL = 'ad.embed';
 
-    private $header = false;
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
@@ -17,8 +17,6 @@ class AnalyticsRule extends ConfigurationSelectorRule
     const PROPERTY_TRACKER_URL = 'analytics.url';
     const PROPERTY_TRACKER_EMBED_URL = 'analytics.embed';
 
-    private $header = false;
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -12,11 +12,6 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 
 class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var InstantArticle
-     */
-    private $article;
-    private $input;
     protected function setUp()
     {
         \Logger::configure(

--- a/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
@@ -13,8 +13,6 @@ use Facebook\InstantArticles\Transformer\Rules\SocialEmbedRule;
 
 class InvalidSelectorTest extends \PHPUnit_Framework_TestCase
 {
-    private $properties;
-
     public function testInvalidSelectorToString()
     {
         $json = <<<'JSON'


### PR DESCRIPTION
This PR

* [x] removes unused `private` fields

💁 They are never assigned a value or read from.