### PR TITLE
Fix: Remove unused private method

### DIFF
--- a/src/Facebook/InstantArticles/Elements/ListElement.php
+++ b/src/Facebook/InstantArticles/Elements/ListElement.php
@@ -123,14 +123,6 @@ class ListElement extends Element
     }
 
     /**
-     * Auxiliary method to find the starting string
-     */
-    private static function startsWith($haystack, $needle)
-    {
-        return substr($haystack, 0, strlen($needle)) === $needle;
-    }
-
-    /**
      * @return string[] the list text items
      */
     public function getItems()


### PR DESCRIPTION
This PR

* [x] removes an unused `private` method