### PR TITLE
Fix: Remove empty constructors

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
@@ -21,10 +21,6 @@ class AdRule extends ConfigurationSelectorRule
 
     private $header = false;
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
@@ -19,10 +19,6 @@ class AnalyticsRule extends ConfigurationSelectorRule
 
     private $header = false;
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnchorRule.php
@@ -16,10 +16,6 @@ class AnchorRule extends ConfigurationSelectorRule
     const PROPERTY_ANCHOR_HREF = 'anchor.href';
     const PROPERTY_ANCHOR_REL = 'anchor.rel';
 
-    public function __construct()
-    {
-    }
-
     public static function create()
     {
         return new AnchorRule();

--- a/src/Facebook/InstantArticles/Transformer/Rules/BlockquoteRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/BlockquoteRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Blockquote;
 
 class BlockquoteRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Bold;
 
 class BoldRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return $this->contextClass = TextContainer::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
@@ -15,10 +15,6 @@ class FooterRelatedArticlesRule extends ConfigurationSelectorRule
 {
     const PROPERTY_TITLE = 'related.title';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Footer::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Footer;
 
 class FooterRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderImageRule.php
@@ -16,10 +16,6 @@ class HeaderImageRule extends ConfigurationSelectorRule
 {
     const PROPERTY_IMAGE_URL = 'image.url';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Header::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
@@ -12,10 +12,6 @@ use Facebook\InstantArticles\Elements\Header;
 
 class HeaderSubTitleRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Header::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
@@ -12,10 +12,6 @@ use Facebook\InstantArticles\Elements\Element;
 
 class IgnoreRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public static function create()
     {
         return new IgnoreRule();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
@@ -18,10 +18,6 @@ class ImageRule extends ConfigurationSelectorRule
     const PROPERTY_LIKE = 'image.like';
     const PROPERTY_COMMENTS = 'image.comments';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InstantArticleRule.php
@@ -19,10 +19,6 @@ class InstantArticleRule extends ConfigurationSelectorRule
     const PROPERTY_MARKUP_VERSION = 'article.markup.version';
     const PROPERTY_AUTO_AD_PLACEMENT = 'article.auto.ad';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Italic;
 
 class ItalicRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public static function create()
     {
         return new ItalicRule();

--- a/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\LineBreak;
 
 class LineBreakRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return $this->contextClass = TextContainer::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ListElementRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ListElementRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\ListElement;
 
 class ListElementRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ListItemRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ListItemRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\ListItem;
 
 class ListItemRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return ListElement::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ParagraphFooterRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ParagraphFooterRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Footer;
 
 class ParagraphFooterRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Footer::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/ParagraphRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ParagraphRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Paragraph;
 
 class ParagraphRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/PassThroughRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/PassThroughRule.php
@@ -12,10 +12,6 @@ use Facebook\InstantArticles\Elements\Element;
 
 class PassThroughRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Element::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/PullquoteRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/PullquoteRule.php
@@ -13,10 +13,6 @@ use Facebook\InstantArticles\Elements\Pullquote;
 
 class PullquoteRule extends ConfigurationSelectorRule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
@@ -15,10 +15,6 @@ class RelatedArticlesRule extends ConfigurationSelectorRule
 {
     const PROPERTY_TITLE = 'related.title';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedItemRule.php
@@ -17,10 +17,6 @@ class RelatedItemRule extends ConfigurationSelectorRule
     const PROPERTY_SPONSORED = 'related.sponsored';
     const PROPERTY_URL = 'related.url';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return RelatedArticles::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
@@ -19,10 +19,6 @@ class SlideshowImageRule extends ConfigurationSelectorRule
     const PROPERTY_CAPTION_TITLE = 'caption.title';
     const PROPERTY_CAPTION_CREDIT = 'caption.credit';
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Slideshow::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/TextNodeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TextNodeRule.php
@@ -12,10 +12,6 @@ use Facebook\InstantArticles\Elements\TextContainer;
 
 class TextNodeRule extends Rule
 {
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return TextContainer::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
@@ -19,10 +19,6 @@ class TimeRule extends ConfigurationSelectorRule
 
     private $type = Time::PUBLISHED;
 
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return Header::getClassName();

--- a/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
@@ -23,11 +23,6 @@ class VideoRule extends ConfigurationSelectorRule
     const PROPERTY_LIKE = 'video.like';
     const PROPERTY_COMMENTS = 'video.comments';
 
-
-    public function __construct()
-    {
-    }
-
     public function getContextClass()
     {
         return InstantArticle::getClassName();


### PR DESCRIPTION
This PR

* [x] removes empty constructors

💁 All of these constructors are `public`, empty, and the parent classes do not declare a constructor - so having them is pretty much useless.