### PR TITLE
Fix: Field contextClass is undefined

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AuthorRule.php
@@ -21,7 +21,7 @@ class AuthorRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return $this->contextClass = Header::getClassName();
+        return Header::getClassName();
     }
 
     public static function create()

--- a/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/BoldRule.php
@@ -19,7 +19,7 @@ class BoldRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return $this->contextClass = TextContainer::getClassName();
+        return TextContainer::getClassName();
     }
 
     public static function create()

--- a/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/IgnoreRule.php
@@ -28,7 +28,7 @@ class IgnoreRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return $this->contextClass = Element::getClassName();
+        return Element::getClassName();
     }
 
     public function apply($transformer, $context, $element)

--- a/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ItalicRule.php
@@ -29,7 +29,7 @@ class ItalicRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return $this->contextClass = TextContainer::getClassName();
+        return TextContainer::getClassName();
     }
 
     public function apply($transformer, $text_container, $element)

--- a/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/LineBreakRule.php
@@ -19,7 +19,7 @@ class LineBreakRule extends ConfigurationSelectorRule
 
     public function getContextClass()
     {
-        return $this->contextClass = TextContainer::getClassName();
+        return TextContainer::getClassName();
     }
 
     public static function create()


### PR DESCRIPTION
This PR

* [x] returns the return value of a method call directly, instead of assigning it to an otherwise undeclared field first and then returning it