### PR TITLE
Fix: Declare fields otherwise declared dynamically

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
@@ -13,6 +13,11 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class ElementGetter extends AbstractGetter
 {
+    /**
+     * @var string
+     */
+    protected $selector;
+
     public function createFrom($properties)
     {
         return $this->withSelector($properties['selector']);

--- a/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/VideoRule.php
@@ -23,6 +23,11 @@ class VideoRule extends ConfigurationSelectorRule
     const PROPERTY_LIKE = 'video.like';
     const PROPERTY_COMMENTS = 'video.comments';
 
+    /**
+     * @var string
+     */
+    private $childSelector;
+
     public function getContextClass()
     {
         return InstantArticle::getClassName();


### PR DESCRIPTION
This PR

* [x] declares fields otherwise declared dynamically