### PR TITLE
H1, H2 and H3 support on Header

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -624,9 +624,11 @@ These rule classes differ slightly from the others because they are permitted in
   - ***Map***
 - `H1Rule`
   - ***Caption***
+  - ***Header***
   - ***InstantArticle***
 - `H2Rule`
   - ***Caption***
+  - ***Header***
   - ***InstantArticle***
 
 ##### Special Rule Classes

--- a/src/Facebook/InstantArticles/Elements/H3.php
+++ b/src/Facebook/InstantArticles/Elements/H3.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Elements;
+
+use Facebook\InstantArticles\Validators\Type;
+
+/**
+ * Title for the Document
+ *
+ * Example:
+ * <h3> This is the first Instant Article</h3>
+ *  or
+ * <h3> This is the <b>first</b> Instant Article</h3>
+ */
+class H3 extends TextContainer
+{
+    /**
+     * @var string text align. Values: "op-left"|"op-center"|"op-right"
+     */
+    private $textAlignment;
+
+    /**
+     * @var string text position. Values: "op-vertical-below"|"op-vertical-above"|"op-vertical-center"
+     */
+    private $position;
+
+    private function __construct()
+    {
+    }
+
+    public static function create()
+    {
+        return new self();
+    }
+
+
+    /**
+     * The Text alignment that will be used.
+     *
+     * @see Caption::ALIGN_RIGHT
+     * @see Caption::ALIGN_LEFT
+     * @see Caption::ALIGN_CENTER
+     *
+     * @param string alignment option that will be used.
+     */
+    public function withTextAlignment($text_alignment)
+    {
+        Type::enforceWithin(
+            $text_alignment,
+            [
+                Caption::ALIGN_RIGHT,
+                Caption::ALIGN_LEFT,
+                Caption::ALIGN_CENTER
+            ]
+        );
+        $this->textAlignment = $text_alignment;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated
+     *
+     * @param string $position
+     * @return $this
+     */
+    public function withPostion($position)
+    {
+        return $this->withPosition($position);
+    }
+
+    /**
+     * The Text position that will be used.
+     *
+     * @see Caption::POSITION_ABOVE
+     * @see Caption::POSITION_BELOW
+     * @see Caption::POSITION_CENTER
+     *
+     * @param string $position
+     * @return $this
+     */
+    public function withPosition($position)
+    {
+        Type::enforceWithin(
+            $position,
+            [
+                Caption::POSITION_ABOVE,
+                Caption::POSITION_BELOW,
+                Caption::POSITION_CENTER
+            ]
+        );
+        $this->position = $position;
+
+        return $this;
+    }
+
+    /**
+     * Structure and create the H3 in a DOMElement.
+     *
+     * @param DOMDocument $document - The document where this element will be appended (optional).
+     */
+    public function toDOMElement($document = null)
+    {
+        if (!$document) {
+            $document = new \DOMDocument();
+        }
+        $h3 = $document->createElement('h3');
+
+        $classes = [];
+        if ($this->position) {
+            $classes[] = $this->position;
+        }
+        if ($this->textAlignment) {
+            $classes[] = $this->textAlignment;
+        }
+        if (!empty($classes)) {
+            $h3->setAttribute('class', implode(' ', $classes));
+        }
+
+        $h3->appendChild($this->textToDOMDocumentFragment($document));
+
+        return $h3;
+    }
+}

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -235,7 +235,7 @@ class Header extends Element
     }
 
     /**
-     * @return string $title The title of the InstantArticle
+     * @return string|H1 $title The title of the InstantArticle
      */
     public function getTitle()
     {
@@ -243,7 +243,7 @@ class Header extends Element
     }
 
     /**
-     * @return string $subtitle The subtitle of the InstantArticle
+     * @return string|H2 $subtitle The subtitle of the InstantArticle
      */
     public function getSubtitle()
     {
@@ -317,7 +317,7 @@ class Header extends Element
         }
 
         if ($this->subtitle) {
-            if (Type::is($this->title, Type::STRING)) {
+            if (Type::is($this->subtitle, Type::STRING)) {
                 $sub_title_element = $document->createElement('h2');
                 $sub_title_element->appendChild($document->createTextNode($this->subtitle));
                 $element->appendChild($sub_title_element);

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -46,12 +46,12 @@ class Header extends Element
     private $cover;
 
     /**
-     * string|H1 The title of the Article that will be displayed on header.
+     * H1 The title of the Article that will be displayed on header.
      */
     private $title;
 
     /**
-     * string|H2 The subtitle of the Article that will be displayed on header.
+     * H2 The subtitle of the Article that will be displayed on header.
      */
     private $subtitle;
 
@@ -72,7 +72,7 @@ class Header extends Element
     private $modified;
 
     /**
-     * @var string Header kicker
+     * @var H3 Header kicker
      */
     private $kicker;
 
@@ -109,7 +109,11 @@ class Header extends Element
     public function withTitle($title)
     {
         Type::enforce($title, array(Type::STRING, H1::getClassName()));
-        $this->title = $title;
+        if (Type::is($title, Type::STRING)) {
+            $this->title = H1::create()->appendText($title);
+        } else {
+            $this->title = $title;
+        }
 
         return $this;
     }
@@ -121,7 +125,12 @@ class Header extends Element
     public function withSubTitle($subtitle)
     {
         Type::enforce($subtitle, array(Type::STRING, H2::getClassName()));
-        $this->subtitle = $subtitle;
+        if (Type::is($subtitle, Type::STRING)) {
+            $this->subtitle = H2::create()->appendText($subtitle);
+        } else {
+            $this->subtitle = $subtitle;
+        }
+
 
         return $this;
     }
@@ -192,12 +201,16 @@ class Header extends Element
 
     /**
      * Kicker text for the article header.
-     * @param string The kicker text to be set
+     * @param H3|string The kicker text to be set
      */
     public function withKicker($kicker)
     {
-        Type::enforce($kicker, Type::STRING);
-        $this->kicker = $kicker;
+        Type::enforce($kicker, array(Type::STRING, H3::getClassName()));
+        if (Type::is($kicker, Type::STRING)) {
+            $this->kicker = H3::create()->appendText($kicker);
+        } else {
+            $this->kicker = $kicker;
+        }
 
         return $this;
     }
@@ -307,23 +320,11 @@ class Header extends Element
         }
 
         if ($this->title) {
-            if (Type::is($this->title, Type::STRING)) {
-                $title_element = $document->createElement('h1');
-                $title_element->appendChild($document->createTextNode($this->title));
-                $element->appendChild($title_element);
-            } else {
-                $element->appendChild($this->title->toDOMElement($document));
-            }
+            $element->appendChild($this->title->toDOMElement($document));
         }
 
         if ($this->subtitle) {
-            if (Type::is($this->subtitle, Type::STRING)) {
-                $sub_title_element = $document->createElement('h2');
-                $sub_title_element->appendChild($document->createTextNode($this->subtitle));
-                $element->appendChild($sub_title_element);
-            } else {
-                $element->appendChild($this->subtitle->toDOMElement($document));
-            }
+            $element->appendChild($this->subtitle->toDOMElement($document));
         }
 
         if ($this->published) {
@@ -343,9 +344,8 @@ class Header extends Element
         }
 
         if ($this->kicker) {
-            $kicker_element = $document->createElement('h3');
+            $kicker_element = $this->kicker->toDOMElement($document);
             $kicker_element->setAttribute('class', 'op-kicker');
-            $kicker_element->appendChild($document->createTextNode($this->kicker));
             $element->appendChild($kicker_element);
         }
 

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -308,13 +308,17 @@ class Header extends Element
 
         if ($this->title) {
             $title_element = $document->createElement('h1');
-            $title_element->appendChild($document->createTextNode($this->title));
+            $title_fragment = $document->createDocumentFragment();
+            $title_fragment->appendXML($this->title);
+            $title_element->appendChild($title_fragment);
             $element->appendChild($title_element);
         }
 
         if ($this->subtitle) {
             $sub_title_element = $document->createElement('h2');
-            $sub_title_element->appendChild($document->createTextNode($this->subtitle));
+            $sub_title_fragment = $document->createDocumentFragment();
+            $sub_title_fragment->appendXML($this->subtitle);
+            $sub_title_element->appendChild($sub_title_fragment);
             $element->appendChild($sub_title_element);
         }
 

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -46,12 +46,12 @@ class Header extends Element
     private $cover;
 
     /**
-     * string The title of the Article that will be displayed on header.
+     * string|H1 The title of the Article that will be displayed on header.
      */
     private $title;
 
     /**
-     * string The subtitle of the Article that will be displayed on header.
+     * string|H2 The subtitle of the Article that will be displayed on header.
      */
     private $subtitle;
 
@@ -104,11 +104,11 @@ class Header extends Element
 
     /**
      * Sets the title of InstantArticle
-     * @param string $title The title of the InstantArticle
+     * @param string|H1 $title The title of the InstantArticle
      */
     public function withTitle($title)
     {
-        Type::enforce($title, Type::STRING);
+        Type::enforce($title, array(Type::STRING, H1::getClassName()));
         $this->title = $title;
 
         return $this;
@@ -116,11 +116,11 @@ class Header extends Element
 
     /**
      * Sets the subtitle of InstantArticle
-     * @param string $subtitle The subtitle of the InstantArticle
+     * @param string|H2 $subtitle The subtitle of the InstantArticle
      */
     public function withSubTitle($subtitle)
     {
-        Type::enforce($subtitle, Type::STRING);
+        Type::enforce($subtitle, array(Type::STRING, H2::getClassName()));
         $this->subtitle = $subtitle;
 
         return $this;
@@ -307,19 +307,23 @@ class Header extends Element
         }
 
         if ($this->title) {
-            $title_element = $document->createElement('h1');
-            $title_fragment = $document->createDocumentFragment();
-            $title_fragment->appendXML($this->title);
-            $title_element->appendChild($title_fragment);
-            $element->appendChild($title_element);
+            if (Type::is($this->title, Type::STRING)) {
+                $title_element = $document->createElement('h1');
+                $title_element->appendChild($document->createTextNode($this->title));
+                $element->appendChild($title_element);
+            } else {
+                $element->appendChild($this->title->toDOMElement($document));
+            }
         }
 
         if ($this->subtitle) {
-            $sub_title_element = $document->createElement('h2');
-            $sub_title_fragment = $document->createDocumentFragment();
-            $sub_title_fragment->appendXML($this->subtitle);
-            $sub_title_element->appendChild($sub_title_fragment);
-            $element->appendChild($sub_title_element);
+            if (Type::is($this->title, Type::STRING)) {
+                $sub_title_element = $document->createElement('h2');
+                $sub_title_element->appendChild($document->createTextNode($this->subtitle));
+                $element->appendChild($sub_title_element);
+            } else {
+                $element->appendChild($this->subtitle->toDOMElement($document));
+            }
         }
 
         if ($this->published) {

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -62,7 +62,8 @@ abstract class TextContainer extends Element
         // Generate markup
         foreach ($this->textChildren as $content) {
             if (Type::is($content, Type::STRING)) {
-                $fragment->appendXML($content);
+                $text = $document->createTextNode($content);
+                $fragment->appendChild($text);
             } else {
                 $fragment->appendChild($content->toDOMElement($document));
             }

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -62,8 +62,7 @@ abstract class TextContainer extends Element
         // Generate markup
         foreach ($this->textChildren as $content) {
             if (Type::is($content, Type::STRING)) {
-                $text = $document->createTextNode($content);
-                $fragment->appendChild($text);
+                $fragment->appendXML($content);
             } else {
                 $fragment->appendChild($content->toDOMElement($document));
             }

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -8,6 +8,7 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
+use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H1;
 use Facebook\InstantArticles\Elements\Instantarticle;
@@ -20,7 +21,7 @@ class H1Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return array(Header::getClassName(), Caption::getClassName(), InstantArticle::getClassName());
     }
 
     public static function create()
@@ -56,7 +57,7 @@ class H1Rule extends ConfigurationSelectorRule
     public function apply($transformer, $context_element, $node)
     {
         $h1 = H1::create();
-        if (Type::is($context_element, Caption::getClassName())) {
+        if (Type::is($context_element, array(Header::getClassName(), Caption::getClassName()))) {
             $context_element->withTitle($h1);
         } elseif (Type::is($context_element, InstantArticle::getClassName())) {
             $context_element->addChild($h1);

--- a/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H2Rule.php
@@ -8,6 +8,7 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
+use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\H2;
 use Facebook\InstantArticles\Elements\Instantarticle;
@@ -20,7 +21,7 @@ class H2Rule extends ConfigurationSelectorRule
 {
     public function getContextClass()
     {
-        return array(Caption::getClassName(), InstantArticle::getClassName());
+        return array(Header::getClassName(), Caption::getClassName(), InstantArticle::getClassName());
     }
 
     public static function create()
@@ -52,7 +53,7 @@ class H2Rule extends ConfigurationSelectorRule
     public function apply($transformer, $context_element, $node)
     {
         $h2 = H2::create();
-        if (Type::is($context_element, Caption::getClassName())) {
+        if (Type::is($context_element, array(Header::getClassName(), Caption::getClassName()))) {
             $context_element->withSubTitle($h2);
         } elseif (Type::is($context_element, InstantArticle::getClassName())) {
             $context_element->addChild($h2);

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderSubTitleRule.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\H2;
 
 class HeaderSubTitleRule extends ConfigurationSelectorRule
 {
@@ -29,7 +30,7 @@ class HeaderSubTitleRule extends ConfigurationSelectorRule
 
     public function apply($transformer, $header, $h2)
     {
-        $header->withSubTitle($h2->textContent);
+        $header->withSubTitle($transformer->transform(H2::create(), $h2));
         return $header;
     }
 }

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderTitleRule.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\H1;
 
 class HeaderTitleRule extends ConfigurationSelectorRule
 {
@@ -29,7 +30,7 @@ class HeaderTitleRule extends ConfigurationSelectorRule
 
     public function apply($transformer, $header, $h1)
     {
-        $header->withTitle($h1->textContent);
+        $header->withTitle($transformer->transform(H1::create(), $h1));
         return $header;
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/H3Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H3Test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Elements;
+
+class H3Test extends \PHPUnit_Framework_TestCase
+{
+    public function testRenderBasic()
+    {
+        $h3 =
+            H3::create()
+                ->appendText('Sub title simple text.');
+
+        $expected =
+            '<h3>'.
+                'Sub title simple text.'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithPosition()
+    {
+        $h3 =
+            H3::create()
+                ->appendText('Sub title simple text.')
+                ->withPosition(Caption::POSITION_ABOVE);
+
+        $expected =
+            '<h3 class="op-vertical-above">'.
+                'Sub title simple text.'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithTextAlign()
+    {
+        $h3 =
+            H3::create()
+                ->appendText('Sub title simple text.')
+                ->withTextAlignment(Caption::ALIGN_LEFT);
+
+        $expected =
+            '<h3 class="op-left">'.
+                'Sub title simple text.'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithPositionAndAlignment()
+    {
+        $h3 =
+            H3::create()
+                ->appendText('Sub title simple text.')
+                ->withPosition(Caption::POSITION_ABOVE)
+                ->withTextAlignment(Caption::ALIGN_LEFT);
+
+        $expected =
+            '<h3 class="op-vertical-above op-left">'.
+                'Sub title simple text.'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithUnescapedHTML()
+    {
+        $h3 =
+            H3::create()
+                ->appendText(
+                    '<b>Some</b> text to be <i>within</i> a <em>paragraph</em> for <strong>testing.</strong>'
+                );
+
+        $expected =
+            '<h3>'.
+                '&lt;b&gt;Some&lt;/b&gt; text to be &lt;i&gt;within&lt;/i&gt; a'.
+                ' &lt;em&gt;paragraph&lt;/em&gt; for &lt;strong&gt;testing.&lt;/strong&gt;'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithFormattedText()
+    {
+        $h3 =
+            H3::create()
+                ->appendText(Bold::create()->appendText('Some'))
+                ->appendText(' text to be ')
+                ->appendText(Italic::create()->appendText('within'))
+                ->appendText(' a ')
+                ->appendText(Italic::create()->appendText('paragraph'))
+                ->appendText(' for ')
+                ->appendText(Bold::create()->appendText('testing.'));
+
+        $expected =
+            '<h3>'.
+                '<b>Some</b> text to be <i>within</i> a <i>paragraph</i> for <b>testing.</b>'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithLink()
+    {
+        $h3 =
+            H3::create()
+                ->appendText('Some ')
+                ->appendText(
+                    Anchor::create()
+                        ->withHRef('http://foo.com')
+                        ->appendText('link')
+                )
+                ->appendText('.');
+
+        $expected =
+            '<h3>'.
+                'Some <a href="http://foo.com">link</a>.'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithNestedFormattedText()
+    {
+        $h3 =
+            H3::create()
+                ->appendText(
+                    Bold::create()
+                        ->appendText('Some ')
+                        ->appendText(Italic::create()->appendText('nested formatting'))
+                        ->appendText('.')
+                );
+
+        $expected =
+            '<h3>'.
+                '<b>Some <i>nested formatting</i>.</b>'.
+            '</h3>';
+
+        $rendered = $h3->render();
+        $this->assertEquals($expected, $rendered);
+    }
+}

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -144,4 +144,28 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $rendered);
     }
+
+    public function testHeaderWithTitles()
+    {
+        $header =
+            Header::create()
+                ->withTitle(
+                    H1::create()
+                        ->appendText('Big Top Title')
+                )
+                ->withSubTitle(
+                    H2::create()
+                        ->appendText('Smaller SubTitle')
+                );
+
+        $expected =
+            '<header>'.
+                '<h1>Big Top Title</h1>'.
+                '<h2>Smaller SubTitle</h2>'.
+            '</header>';
+
+        $rendered = $header->render();
+
+        $this->assertEquals($expected, $rendered);
+    }
 }

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -168,4 +168,30 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $rendered);
     }
+
+    public function testHeaderWithTitlesFormatted()
+    {
+        $header =
+            Header::create()
+                ->withTitle(
+                    H1::create()
+                        ->appendText('Big Top Title ')
+                        ->appendText(Bold::create()->appendText('in Bold'))
+                )
+                ->withSubTitle(
+                    H2::create()
+                        ->appendText('Smaller SubTitle ')
+                        ->appendText(Bold::create()->appendText('in Bold'))
+                );
+
+        $expected =
+            '<header>'.
+                '<h1>Big Top Title <b>in Bold</b></h1>'.
+                '<h2>Smaller SubTitle <b>in Bold</b></h2>'.
+            '</header>';
+
+        $rendered = $header->render();
+
+        $this->assertEquals($expected, $rendered);
+    }
 }

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -156,12 +156,17 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
                 ->withSubTitle(
                     H2::create()
                         ->appendText('Smaller SubTitle')
+                )
+                ->withKicker(
+                    H3::create()
+                        ->appendText('Kicker')
                 );
 
         $expected =
             '<header>'.
                 '<h1>Big Top Title</h1>'.
                 '<h2>Smaller SubTitle</h2>'.
+                '<h3 class="op-kicker">Kicker</h3>'.
             '</header>';
 
         $rendered = $header->render();
@@ -182,12 +187,18 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
                     H2::create()
                         ->appendText('Smaller SubTitle ')
                         ->appendText(Bold::create()->appendText('in Bold'))
+                )
+                ->withKicker(
+                    H3::create()
+                        ->appendText('Kicker ')
+                        ->appendText(Bold::create()->appendText('in Bold'))
                 );
 
         $expected =
             '<header>'.
                 '<h1>Big Top Title <b>in Bold</b></h1>'.
                 '<h2>Smaller SubTitle <b>in Bold</b></h2>'.
+                '<h3 class="op-kicker">Kicker <b>in Bold</b></h3>'.
             '</header>';
 
         $rendered = $header->render();

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.xml
@@ -15,8 +15,8 @@
           <img src="http://domain.com/image-header.png"/>
           <figcaption>Some amazing moment captured by Photographer</figcaption>
         </figure>
-        <h1>The article title</h1>
-        <h2>Sub Title</h2>
+        <h1>The article <b>title</b></h1>
+        <h2>Sub <b>Title</b></h2>
         <address><a>Author name</a></address>
       </header>
       <p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit. Sed eu arcu porta, ultrices massa ut, porttitor diam. Integer id auctor augue.</p>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple.html
@@ -4,8 +4,8 @@
     </head>
     <body>
         <div class="header">
-            <h1>The article title</h1>
-            <h2>Sub Title</h2>
+            <h1>The article <b>title</b></h1>
+            <h2>Sub <b>Title</b></h2>
             <span class="author">Author name</span>
             <div class="hero-image">
                 <img src="http://domain.com/image-header.png" />

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
@@ -15,8 +15,8 @@
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
           <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
         </figure>
-        <h1>Big Top Title</h1>
-        <h2>Smaller SubTitle</h2>
+        <h1>Big Top <b>Title</b></h1>
+        <h2>Smaller <b>SubTitle</b></h2>
         <time class="op-published" datetime="1984-08-14T19:30:00+00:00">August 14th, 7:30pm</time>
         <time class="op-modified" datetime="2016-02-10T10:00:00+00:00">February 10th, 10:00am</time>
         <address><a href="#" title="Title of author">Author Name</a>


### PR DESCRIPTION
This PR is an definition over the suggested PR from @gemedet https://github.com/facebook/facebook-instant-articles-sdk-php/pull/32

It allows markup text inside H1, H2 and H3 like:
```html
    <header>
        <h1>Some title <b>in Bold</b></h1>
        <h2>Some subtitle <i>in Italic</i></h2>
        <h3 class="op-kicker">Some kicker <i>in Italic</i></h3>
    </header>
```