### PR TITLE
Enhancement: Allow to specify article as string

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -81,20 +81,26 @@ class Client
     /**
      * Import an article into your Instant Articles library.
      *
-     * @param InstantArticle $article The article to import
+     * @param string|InstantArticle $article The article to import, either as a string or an InstantArticle object.
      * @param bool|false $takeLive Specifies if this article should be taken live or not. Optional. Default: false.
      */
     public function importArticle($article, $takeLive = false)
     {
-        Type::enforce($article, InstantArticle::getClassName());
+        Type::enforce($article, [
+            InstantArticle::getClassName(),
+            Type::STRING
+        ]);
+
         Type::enforce($takeLive, Type::BOOLEAN);
 
         // Never try to take live if we're in development (the API would throw an error if we tried)
         $takeLive = $this->developmentMode ? false : $takeLive;
 
+        $htmlSource = $article instanceof InstantArticle ? $article->render() : $article;
+
         // Assume default access token is set on $this->facebook
         $this->facebook->post($this->pageID . Client::EDGE_NAME, [
-          'html_source' => $article->render(),
+          'html_source' => $htmlSource,
           'take_live' => $takeLive,
           'development_mode' => $this->developmentMode,
         ]);

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -50,6 +50,23 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->importArticle($this->article);
     }
 
+    public function testImportArticleAcceptsHtmlSource()
+    {
+        $htmlSource = $this->article->render();
+
+        $this->facebook
+            ->expects($this->once())
+            ->method('post')
+            ->with('PAGE_ID' . Client::EDGE_NAME, [
+                'html_source' => $htmlSource,
+                'take_live' => false,
+                'development_mode' => false,
+            ])
+        ;
+
+        $this->client->importArticle($htmlSource);
+    }
+
     public function testImportArticleTakeLive()
     {
         $this->facebook


### PR DESCRIPTION
This PR

* [x] adjusts the `Client` to accept both an `InstantArticle` as well as a `string` when importing an article

Fixes #96.

