### PR TITLE
Width and Height for SocialEmbed

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -658,7 +658,7 @@ Rule Class | Properties | Permitted Context | Notes
 `RelatedItemRule` | `related.sponsored`<br>`related.url` | *RelatedArticles* | For individual articles within a `RelatedArticlesRule`
 `SlideshowImageRule` | `image.url`<br>`caption.title`<br>`caption.credit` | *Slideshow* | For individual images within a `SlideshowRule`
 `SlideshowRule` |  | *InstantArticle* | Wrapper for a [Slideshow](https://developers.facebook.com/docs/instant-articles/reference/slideshow) component
-`SocialEmbedRule` | `socialembed.iframe`<br>`socialembed.url` | *InstantArticle* |
+`SocialEmbedRule` | `socialembed.iframe`<br>`socialembed.url`<br>`socialembed.width`<br>`socialembed.height` | *InstantArticle* |
 `VideoRule` | `video.url`<br>`video.type`<br>`video.playback`<br>`video.controls`<br>`video.like`<br>`video.comments`<br><br>`type` = `"exists"` for any of the video player options:<br>`loop`<br>`data-fade`<br><br>one of the following:<br>`aspect-fit`<br>`aspect-fit-only`<br>`fullscreen`<br>`non-interactive` | *InstantArticle* |
 
 **Article Structure**

--- a/src/Facebook/InstantArticles/Elements/SocialEmbed.php
+++ b/src/Facebook/InstantArticles/Elements/SocialEmbed.php
@@ -39,6 +39,16 @@ class SocialEmbed extends Element
      */
     private $source;
 
+    /**
+     * @var int The width of your social embed.
+     */
+    private $width;
+
+    /**
+     * @var int The height of your social embed.
+     */
+    private $height;
+
     private function __construct()
     {
     }
@@ -97,6 +107,36 @@ class SocialEmbed extends Element
     }
 
     /**
+     * Sets the width of your social embed.
+     *
+     * @param int $width The width of your social embed.
+     *
+     * @return $this
+     */
+    public function withWidth($width)
+    {
+        Type::enforce($width, Type::INTEGER);
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * Sets the height of your social embed.
+     *
+     * @param int $height The height of your social embed.
+     *
+     * @return $this
+     */
+    public function withHeight($height)
+    {
+        Type::enforce($height, Type::INTEGER);
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
      * @return Caption - The caption for social embed block
      */
     public function getCaption()
@@ -118,6 +158,22 @@ class SocialEmbed extends Element
     public function getSource()
     {
         return $this->source;
+    }
+
+    /**
+     * @return int the width
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * @return int the height
+     */
+    public function getHeight()
+    {
+        return $this->height;
     }
 
     /**
@@ -144,6 +200,14 @@ class SocialEmbed extends Element
 
         if ($this->source) {
             $iframe->setAttribute('src', $this->source);
+        }
+
+        if ($this->width) {
+            $iframe->setAttribute('width', $this->width);
+        }
+
+        if ($this->height) {
+            $iframe->setAttribute('height', $this->height);
         }
 
         $figure->setAttribute('class', 'op-social');

--- a/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
@@ -16,6 +16,8 @@ class SocialEmbedRule extends ConfigurationSelectorRule
 {
     const PROPERTY_IFRAME = 'socialembed.iframe';
     const PROPERTY_URL = 'socialembed.url';
+    const PROPERTY_WIDTH = 'socialembed.width';
+    const PROPERTY_HEIGHT = 'socialembed.height';
 
     public function getContextClass()
     {
@@ -35,7 +37,9 @@ class SocialEmbedRule extends ConfigurationSelectorRule
         $social_embed_rule->withProperties(
             [
                 self::PROPERTY_IFRAME,
-                self::PROPERTY_URL
+                self::PROPERTY_URL,
+                self::PROPERTY_WIDTH,
+                self::PROPERTY_HEIGHT
             ],
             $configuration
         );
@@ -67,6 +71,16 @@ class SocialEmbedRule extends ConfigurationSelectorRule
                     $this
                 )
             );
+        }
+
+        // Dimensions
+        $width = $this->getProperty(self::PROPERTY_WIDTH, $node);
+        $height = $this->getProperty(self::PROPERTY_HEIGHT, $node);
+        if ($width) {
+            $social_embed->withWidth($width);
+        }
+        if ($height) {
+            $social_embed->withHeight($height);
         }
 
         $suppress_warnings = $transformer->suppress_warnings;

--- a/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SocialEmbedTest.php
@@ -69,4 +69,21 @@ class SocialEmbedTest extends \PHPUnit_Framework_TestCase
         $rendered = $social_embed->render();
         $this->assertEquals($expected, $rendered);
     }
+
+    public function testRenderWithWidthAndHeight()
+    {
+        $social_embed =
+            SocialEmbed::create()
+                ->withSource('http://foo.com')
+                ->withWidth(640)
+                ->withHeight(480);
+
+        $expected =
+            '<figure class="op-social">'.
+                '<iframe src="http://foo.com" width="640" height="480"></iframe>'.
+            '</figure>';
+
+        $rendered = $social_embed->render();
+        $this->assertEquals($expected, $rendered);
+    }
 }


### PR DESCRIPTION
This PR adds Width and Height properties to the SocialEmbed element, allowing for markup such as:
```html
<figure class="op-social">
    <iframe src="http://foo.com" width="640" height="480"></iframe>
</figure>
```