### PR TITLE
Ignore HTML doctypes and XML prologs

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -167,6 +167,8 @@ class Transformer
                 if (!$matched &&
                     !($child->nodeName === '#text' && trim($child->textContent) === '') &&
                     !($child->nodeName === '#comment') &&
+                    !($child->nodeName === 'html' && Type::is($child, 'DOMDocumentType')) &&
+                    !($child->nodeName === 'xml' && Type::is($child, 'DOMProcessingInstruction')) &&
                     !$this->suppress_warnings
                     ) {
                     $tag_content = $child->ownerDocument->saveXML($child);


### PR DESCRIPTION
This PR makes the Transformer ignore declarations such as `<!doctype html>` and `<?xml encoding="utf-8" ?>`.

Fixes Automattic/facebook-instant-articles-wp#206.

