### PR TITLE
InstantArticle interface

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -12,6 +12,7 @@ namespace Facebook\InstantArticles\Client;
 use Facebook\Exceptions\FacebookSDKException;
 use Facebook\Facebook;
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Elements\InstantArticleInterface;
 use Facebook\InstantArticles\Validators\Type;
 
 class Client
@@ -87,7 +88,7 @@ class Client
      */
     public function importArticle($article, $takeLive = false)
     {
-        Type::enforce($article, InstantArticle::getClassName());
+        Type::enforce($article, 'Facebook\InstantArticles\Elements\InstantArticleInterface');
         Type::enforce($takeLive, Type::BOOLEAN);
 
         // Never try to take live if we're in development (the API would throw an error if we tried)

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -31,7 +31,8 @@ use Facebook\InstantArticles\Validators\Type;
   *    </html>
   *
 */
-class InstantArticle extends Element implements Container
+
+class InstantArticle extends Element implements Container, InstantArticleInterface
 {
     const CURRENT_VERSION = '1.1.0';
 

--- a/src/Facebook/InstantArticles/Elements/InstantArticleInterface.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticleInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Elements;
+
+interface InstantArticleInterface
+{
+    public function render();
+}

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -380,7 +380,6 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
-
     public function testIsValid()
     {
         $ia =
@@ -413,9 +412,9 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 );
         $this->assertTrue($ia->isValid());
     }
-    
+
     public function testImplementsInterface()
     {
-        $this->assertInstanceOf(InstantArticleInterface::class, $this->article);
+        $this->assertInstanceOf('Facebook\InstantArticles\Elements\InstantArticleInterface', $this->article);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -380,6 +380,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+
     public function testIsValid()
     {
         $ia =
@@ -411,5 +412,10 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                         ->appendText(' Man kind.')
                 );
         $this->assertTrue($ia->isValid());
+    }
+    
+    public function testImplementsInterface()
+    {
+        $this->assertInstanceOf(InstantArticleInterface::class, $this->article);
     }
 }


### PR DESCRIPTION
This PR

* [x] introduces `InstantArticleInterface`

The goal of this PR is to decouple `Client` from `InstantArticle` concrete implementation by providing `InstantArticleInterface` so `Client` can be used by any instant article implementation as long as it implements this contract.


Related to https://github.com/facebook/facebook-instant-articles-sdk-php/pull/97.
Fixes https://github.com/facebook/facebook-instant-articles-sdk-php/issues/96.
