### PR TITLE
Fix: Configure whitelist filter for coverage generation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
This PR

* [x] configures a whitelist filter for generating code coverage

💁 Without the filter, `phpunit` complains:

```
$ vendor/bin/phpunit --coverage-text
PHPUnit 4.8.24 by Sebastian Bergmann and contributors.
Warning:	No whitelist configured for code coverage

...............................................................  63 / 216 ( 29%)
............................................................... 126 / 216 ( 58%)
............................................................... 189 / 216 ( 87%)
...........................

Time: 9.07 seconds, Memory: 26.75Mb

OK (216 tests, 248 assertions)
```