### PR TITLE
Fix: Reference Exception from root namespace

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
@@ -48,7 +48,7 @@ abstract class Rule
     public static function create()
     {
         throw new \Exception(
-            'All Rule class extension should implement the '.
+            'All Rule class extensions should implement the '.
             'Rule::create() method'
         );
     }
@@ -56,7 +56,7 @@ abstract class Rule
     public static function createFrom($configuration)
     {
         throw new \Exception(
-            'All Rule class extension should implement the '.
+            'All Rule class extensions should implement the '.
             'Rule::createFrom($configuration) method'
         );
     }

--- a/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
@@ -47,7 +47,7 @@ abstract class Rule
 
     public static function create()
     {
-        throw new Exception(
+        throw new \Exception(
             'All Rule class extension should implement the '.
             'Rule::create() method'
         );
@@ -55,7 +55,7 @@ abstract class Rule
 
     public static function createFrom($configuration)
     {
-        throw new Exception(
+        throw new \Exception(
             'All Rule class extension should implement the '.
             'Rule::createFrom($configuration) method'
         );

--- a/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Rules;
+
+class RuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateFromPropertiesThrowsException()
+    {
+        $this->setExpectedException(
+            'Exception',
+            'All Rule class extensions should implement the Rule::createFrom($configuration) method'
+        );
+
+        Rule::createFrom([]);
+    }
+
+    public function testCreateThrowsException()
+    {
+        $this->setExpectedException(
+            'Exception',
+            'All Rule class extensions should implement the Rule::create() method'
+        );
+
+        Rule::create();
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that `Rule::create()` and `Rule::createFrom()` throw exceptions
* [x] references `Exception` from root namespace
* [x] fixes exception messages

