### PR TITLE
Fix: Access to instance member

### DIFF
--- a/src/Facebook/InstantArticles/Client/Helper.php
+++ b/src/Facebook/InstantArticles/Client/Helper.php
@@ -90,7 +90,7 @@ class Helper
         try {
             $response = $this->facebook->get('/me/accounts?fields=name,id,access_token,supports_instant_articles');
         } catch (Facebook\Exceptions\FacebookResponseException $e) {
-            throw new FacebookSDKException('Graph API returned an error: ' . $e.getMessage());
+            throw new FacebookSDKException('Graph API returned an error: ' . $e->getMessage());
         }
 
         // Return the array of page objects for this user


### PR DESCRIPTION
This PR

* [x] fixes an attempt to invoke the `getMessage()` method on an exception
