### PR TITLE
Fix: Remove unused import

### DIFF
--- a/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
@@ -10,15 +10,12 @@ namespace Facebook\InstantArticles\Validators;
 
 use Facebook\InstantArticles\Elements\Ad;
 use Facebook\InstantArticles\Elements\Analytics;
-use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Image;
-use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Footer;
 use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\SlideShow;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\Elements\AnimatedGIF;
 
 /**
  * Test unit against InstantArticleValidator


### PR DESCRIPTION
This PR

* [x] removes an unused import 

@everton-rosario @simonengelhardt Would you consider switching to `fabpot/php-cs-fixer`? While `squizlabs/php_codesniffer` is a great tool, `fabpot/php-cs-fixer` has a lot more interesting fixes, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage.