### PR TITLE
Enhancement: Use fzaninotto/faker to generate fake data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "apache/log4php": "2.3.0"
     },
     "require-dev": {
+        "fzaninotto/faker": "^1.6.0",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.6.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "398f72427cce7dfe69b94976676d20ae",
-    "content-hash": "9c537b7471f03635dcca5e90fdd23cde",
+    "hash": "1cb48da59b04851b1ddcce5ac4a16e91",
+    "content-hash": "e47809dbb41d3cf5a6049a4db9fe2301",
     "packages": [
         {
             "name": "apache/log4php",
@@ -200,6 +200,54 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2016-04-29 12:21:54"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -8,8 +8,12 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
+use Facebook\InstantArticles\Transformer\GeneratorTrait;
+
 class AdTest extends \PHPUnit_Framework_TestCase
 {
+    use GeneratorTrait;
+
     public function testRenderEmpty()
     {
         $ad = Ad::create();
@@ -22,13 +26,15 @@ class AdTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderBasic()
     {
+        $source = $this->getFaker()->url;
+
         $ad =
             Ad::create()
-                ->withSource('http://foo.com');
+                ->withSource($source);
 
         $expected =
             '<figure class="op-ad">'.
-                '<iframe src="http://foo.com"></iframe>'.
+                '<iframe src="'. $source . '"></iframe>'.
             '</figure>';
 
         $rendered = $ad->render();

--- a/tests/Facebook/InstantArticles/Transformer/GeneratorTrait.php
+++ b/tests/Facebook/InstantArticles/Transformer/GeneratorTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+namespace Facebook\InstantArticles\Transformer;
+
+use Faker\Factory;
+use Faker\Generator;
+
+trait GeneratorTrait
+{
+    /**
+     * @return Generator
+     */
+    protected function getFaker()
+    {
+        static $faker;
+
+        if ($faker === null) {
+            $faker = Factory::create();
+            $faker->seed(9000);
+        }
+
+        return $faker;
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires [`fzaninotto/faker`](https://github.com/fzaninotto/Faker)
* [x] implements a `GeneratorTrait` which can be used in tests to utilize an instance of `Faker\Generator` to fake data
* [x] provides an example of using the `GeneratorTrait`

💁 Because we're too lazy to think about test data, right?! For reference, also see [`refinery29/test-util`](https://github.com/refinery29/test-util/blob/master/src/Faker/GeneratorTrait.php).