### PR TITLE
Fix: Remove unused local variables

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -31,7 +31,6 @@ abstract class Element
     public function render($doctype = '', $formatted = false)
     {
         $document = new \DOMDocument();
-        $rendered = '';
         $document->preserveWhiteSpace = !$formatted;
         $document->formatOutput = $formatted;
         $element = $this->toDOMElement($document);

--- a/src/Facebook/InstantArticles/Transformer/Warnings/ValidatorWarning.php
+++ b/src/Facebook/InstantArticles/Transformer/Warnings/ValidatorWarning.php
@@ -49,7 +49,6 @@ class ValidatorWarning
 
     private function formatWarningMessage()
     {
-        $message = '';
         $object = Type::stringify($this->element);
         if (!$this->configuration) {
             $this->configuration = parse_ini_file("validator_warning_messages.ini", true);

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -50,7 +50,6 @@ class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
         $transformer->transform($instant_article, $document);
         $instant_article->addMetaProperty('op:generator:version', '1.0.0');
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
-        $warnings = $transformer->getWarnings();
         $result = $instant_article->render('', true)."\n";
         $expected = file_get_contents(__DIR__ . '/simple-ia.xml');
 

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -53,7 +53,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $transformer->transform($instant_article, $document);
         $instant_article->addMetaProperty('op:generator:version', '1.0.0');
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
-        $warnings = $transformer->getWarnings();
         $result = $instant_article->render('', true)."\n";
 
         //var_dump($result);


### PR DESCRIPTION
This PR

* [x] removes unused local variable 

🙎 These variables are assigned a value, but never used, or immediately overwritten.
