### PR TITLE
Fix: Send the message as a ServerMessage.

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -124,7 +124,7 @@ class Client
             $this->facebook->delete($articleID);
             return InstantArticleStatus::success();
         }
-        return InstantArticleStatus::notFound(['An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.']);
+        return InstantArticleStatus::notFound([ServerMessage::info('An Instant Article ID ' . $articleID . ' was not found for ' . $canonicalURL . ' in ' . __FUNCTION__ . '.')]);
     }
 
     /**


### PR DESCRIPTION
An InvalidArgumentException was being thrown when a InstantArticleStatus::notFound was being called due to the message being sent as a string and not a ServerMessage.