### PR TITLE
Fix development mode article lookup

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -138,8 +138,10 @@ class Client
     {
         Type::enforce($canonicalURL, Type::STRING);
 
-        $response = $this->facebook->get('?id=' . $canonicalURL . '&fields=instant_article');
-        $instantArticle = $response->getGraphNode()->getField('instant_article');
+        $field = $this->developmentMode ? 'development_instant_article' : 'instant_article';
+
+        $response = $this->facebook->get('?id=' . $canonicalURL . '&fields=' . $field);
+        $instantArticle = $response->getGraphNode()->getField($field);
 
         if (!$instantArticle) {
             return null;

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -212,6 +212,97 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedArticleID, $articleID);
     }
 
+    public function testDevelopmentModeGetArticleIDFromCanonicalURL()
+    {
+        $canonicalURL = "http://facebook.com";
+
+        $expectedArticleID = 123;
+
+        $serverResponseMock =
+            $this->getMockBuilder('Facebook\FacebookResponse')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $graphNodeMock =
+            $this->getMockBuilder('Facebook\GraphNodes\GraphNode')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $instantArticleMock =
+            $this->getMockBuilder('Facebook\GraphNodes\GraphNode')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $instantArticleMock
+            ->expects($this->once())
+            ->method('getField')
+            ->with($this->equalTo('id'))
+            ->willReturn($expectedArticleID);
+        $graphNodeMock
+            ->expects($this->once())
+            ->method('getField')
+            ->with($this->equalTo('development_instant_article'))
+            ->willReturn($instantArticleMock);
+        $serverResponseMock
+            ->expects($this->once())
+            ->method('getGraphNode')
+            ->willReturn($graphNodeMock);
+        $this->facebook
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('?id='.$canonicalURL.'&fields=development_instant_article'))
+            ->willReturn($serverResponseMock);
+
+        // Set up new client in development mode
+        $this->client = new Client(
+            $this->facebook,
+            "PAGE_ID",
+            true // developmentMode
+        );
+
+        $articleID = $this->client->getArticleIDFromCanonicalURL($canonicalURL);
+        $this->assertEquals($expectedArticleID, $articleID);
+    }
+
+    public function testDevelopmentModeGetArticleIDFromNotFoundCanonicalURL()
+    {
+        $canonicalURL = "http://facebook.com";
+
+        $expectedArticleID = null;
+
+        $serverResponseMock =
+            $this->getMockBuilder('Facebook\FacebookResponse')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $graphNodeMock =
+            $this->getMockBuilder('Facebook\GraphNodes\GraphNode')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $graphNodeMock
+            ->expects($this->once())
+            ->method('getField')
+            ->with($this->equalTo('development_instant_article'))
+            ->willReturn(null);
+        $serverResponseMock
+            ->expects($this->once())
+            ->method('getGraphNode')
+            ->willReturn($graphNodeMock);
+        $this->facebook
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('?id='.$canonicalURL.'&fields=development_instant_article'))
+            ->willReturn($serverResponseMock);
+
+        // Set up new client in development mode
+        $this->client = new Client(
+            $this->facebook,
+            "PAGE_ID",
+            true // developmentMode
+        );
+
+        $articleID = $this->client->getArticleIDFromCanonicalURL($canonicalURL);
+        $this->assertEquals($expectedArticleID, $articleID);
+    }
+
     public function testGetLastSubmissionStatus()
     {
         $articleID = '123';


### PR DESCRIPTION
This PR

* [x] Enables looking up Instant Articles in development mode

When `Client` is operating in dev mode, articles must be looked up using the `development_instant_article` field.