### PR TITLE
Updated interactive to better align with documentation update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.phar
 /vendor/
 *.ignored
 **/IgnoredTest.php
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ composer.phar
 /vendor/
 *.ignored
 **/IgnoredTest.php
-.idea

--- a/src/Facebook/InstantArticles/Elements/Interactive.php
+++ b/src/Facebook/InstantArticles/Elements/Interactive.php
@@ -32,6 +32,11 @@ class Interactive extends Element implements Container
     private $caption;
 
     /**
+     * @var int The width of your interactive graphic.
+     */
+    private $width;
+
+    /**
      * @var int The height of your interactive graphic.
      */
     private $height;
@@ -46,7 +51,7 @@ class Interactive extends Element implements Container
      * @see Interactive::NO_MARGIN
      * @see Interactive::COLUMN_WIDTH
      */
-    private $width;
+    private $margin;
 
     /**
      * @var \DOMNode The HTML of the content.
@@ -73,6 +78,20 @@ class Interactive extends Element implements Container
     {
         Type::enforce($caption, Caption::getClassName());
         $this->caption = $caption;
+
+        return $this;
+    }
+
+    /**
+     * Sets the width of your interactive graphic.
+     *
+     * @param int $width The height of your interactive graphic.
+     *
+     * @return $this
+     */
+    public function withWidth($width) {
+        Type::enforce($width, Type::INTEGER);
+        $this->width = $width;
 
         return $this;
     }
@@ -108,25 +127,25 @@ class Interactive extends Element implements Container
     }
 
     /**
-     * Sets the width setting of your interactive graphic.
+     * Sets the margin setting of your interactive graphic.
      *
-     * @param string $width The width setting of your interactive graphic.
+     * @param string $margin The margin setting of your interactive graphic.
      *
      * @see Interactive::NO_MARGIN
      * @see Interactive::COLUMN_WIDTH
      *
      * @return $this
      */
-    public function withWidth($width)
+    public function withMargin($margin)
     {
         Type::enforceWithin(
-            $width,
+            $margin,
             [
                 Interactive::NO_MARGIN,
                 Interactive::COLUMN_WIDTH
             ]
         );
-        $this->width = $width;
+        $this->margin = $margin;
 
         return $this;
     }
@@ -155,6 +174,13 @@ class Interactive extends Element implements Container
     }
 
     /**
+     * @return int the width
+     */
+    public function getWidth() {
+        return $this->width;
+    }
+
+    /**
      * @return int the height
      */
     public function getHeight()
@@ -171,11 +197,11 @@ class Interactive extends Element implements Container
     }
 
     /**
-     * @return int the width
+     * @return string the margin
      */
-    public function getWidth()
+    public function getMargin()
     {
-        return $this->width;
+        return $this->margin;
     }
 
     /**
@@ -218,8 +244,12 @@ class Interactive extends Element implements Container
             $iframe->setAttribute('src', $this->source);
         }
 
+        if ($this->margin) {
+            $iframe->setAttribute('class', $this->margin);
+        }
+
         if ($this->width) {
-            $iframe->setAttribute('class', $this->width);
+            $iframe->setAttribute('width', $this->width);
         }
 
         if ($this->height) {

--- a/src/Facebook/InstantArticles/Elements/Interactive.php
+++ b/src/Facebook/InstantArticles/Elements/Interactive.php
@@ -89,7 +89,8 @@ class Interactive extends Element implements Container
      *
      * @return $this
      */
-    public function withWidth($width) {
+    public function withWidth($width)
+    {
         Type::enforce($width, Type::INTEGER);
         $this->width = $width;
 
@@ -176,7 +177,8 @@ class Interactive extends Element implements Container
     /**
      * @return int the width
      */
-    public function getWidth() {
+    public function getWidth()
+    {
         return $this->width;
     }
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
@@ -19,6 +19,7 @@ class InteractiveRule extends ConfigurationSelectorRule
     const PROPERTY_WIDTH_NO_MARGIN = Interactive::NO_MARGIN;
     const PROPERTY_WIDTH_COLUMN_WIDTH = Interactive::COLUMN_WIDTH;
     const PROPERTY_HEIGHT = 'interactive.height';
+    const PROPERTY_WIDTH = 'interactive.width';
 
     public function getContextClass()
     {
@@ -41,6 +42,7 @@ class InteractiveRule extends ConfigurationSelectorRule
                 self::PROPERTY_URL,
                 self::PROPERTY_WIDTH_NO_MARGIN,
                 self::PROPERTY_WIDTH_COLUMN_WIDTH,
+                self::PROPERTY_WIDTH,
                 self::PROPERTY_HEIGHT
             ],
             $configuration
@@ -76,9 +78,14 @@ class InteractiveRule extends ConfigurationSelectorRule
         }
 
         if ($this->getProperty(self::PROPERTY_WIDTH_COLUMN_WIDTH, $node)) {
-            $interactive->withWidth(Interactive::COLUMN_WIDTH);
+            $interactive->withMargin(Interactive::COLUMN_WIDTH);
         } else {
-            $interactive->withWidth(Interactive::NO_MARGIN);
+            $interactive->withMargin(Interactive::NO_MARGIN);
+        }
+
+        $width = $this->getProperty(self::PROPERTY_WIDTH, $node);
+        if ($width) {
+            $interactive->withWidth($width);
         }
 
         $height = $this->getProperty(self::PROPERTY_HEIGHT, $node);

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -74,7 +74,8 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    public function testRenderBasicWithWidth() {
+    public function testRenderBasicWithWidth()
+    {
         $interactive =
           Interactive::create()
             ->withSource('http://foo.com/interactive-graphic')
@@ -89,7 +90,8 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    public function testRenderBasicWithWidthHeight() {
+    public function testRenderBasicWithWidthHeight()
+    {
         $interactive =
           Interactive::create()
             ->withSource('http://foo.com/interactive-graphic')

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -150,7 +150,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
             Interactive::create()
                 ->withHTML($fragment)
                 ->withHeight(640)
-                ->withWidth(Interactive::NO_MARGIN);
+                ->withMargin(Interactive::NO_MARGIN);
 
         $expected =
             '<figure class="op-interactive">'.

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -74,12 +74,43 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
+    public function testRenderBasicWithWidth() {
+        $interactive =
+          Interactive::create()
+            ->withSource('http://foo.com/interactive-graphic')
+            ->withWidth(640);
+
+        $expected =
+          '<figure class="op-interactive">' .
+          '<iframe src="http://foo.com/interactive-graphic" width="640"></iframe>' .
+          '</figure>';
+
+        $rendered = $interactive->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderBasicWithWidthHeight() {
+        $interactive =
+          Interactive::create()
+            ->withSource('http://foo.com/interactive-graphic')
+            ->withWidth(1600)
+            ->withHeight(900);
+
+        $expected =
+          '<figure class="op-interactive">' .
+          '<iframe src="http://foo.com/interactive-graphic" width="1600" height="900"></iframe>' .
+          '</figure>';
+
+        $rendered = $interactive->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
     public function testRenderBasicWithColumnWidth()
     {
         $interactive =
             Interactive::create()
                 ->withSource('http://foo.com/interactive-graphic')
-                ->withWidth(Interactive::COLUMN_WIDTH);
+                ->withMargin(Interactive::COLUMN_WIDTH);
 
         $expected =
             '<figure class="op-interactive">'.
@@ -95,7 +126,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $interactive =
             Interactive::create()
                 ->withSource('http://foo.com/interactive-graphic')
-                ->withWidth(Interactive::NO_MARGIN);
+                ->withMargin(Interactive::NO_MARGIN);
 
         $expected =
             '<figure class="op-interactive">'.

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-rules.json
@@ -544,6 +544,11 @@
                         "selector" : "iframe",
                         "attribute": "height"
                     },
+                    "interactive.width": {
+                        "type": "int",
+                        "selector": "iframe",
+                        "attribute": "width"
+                    },
                     "interactive.iframe" : {
                         "type" : "children",
                         "selector" : "iframe"


### PR DESCRIPTION
From https://developers.facebook.com/docs/instant-articles/reference/embeds

```If you implement your embed using a src attribute on the <iframe> element, we recommend that you specify both the width and height of your <iframe>. Otherwise, your embedded media may be scaled incorrectly and get cropped. If the size you specify is too wide for the phone’s screen, we will automatically scale the embed down while maintaining its aspect ratio.```

Renamed the existing width property on interactive to be margin.  Added width property to support the actual width for the iframe in interactive.