### PR TITLE
Move validation outside of the transfomation loop

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -202,13 +202,6 @@ class Transformer
             }
         }
 
-        if (Type::is($context, InstantArticle::getClassName())) {
-            $ia_warnings = InstantArticleValidator::check($context);
-            foreach ($ia_warnings as $ia_warning) {
-                $this->addWarning($ia_warning);
-            }
-        }
-
         return $context;
     }
 

--- a/src/Facebook/InstantArticles/Transformer/Warnings/ValidatorWarning.php
+++ b/src/Facebook/InstantArticles/Transformer/Warnings/ValidatorWarning.php
@@ -71,9 +71,9 @@ class ValidatorWarning
         $simple_class_name = substr(strrchr($this->element->getClassName(), '\\'), 1);
 
         if (!isset($this->configuration['warning_messages'][$simple_class_name])) {
-            $message = 'Invalid content on the object: '.$object;
+            $message = 'Invalid content on the object.';
         } else {
-            $message = $this->configuration['warning_messages'][$simple_class_name] . 'Element content: '.$object;
+            $message = $this->configuration['warning_messages'][$simple_class_name];
         }
         return $message;
     }


### PR DESCRIPTION
This PR:

- Fixes the message of the warning coming from the Validator to no include a string representation of the object (the consumer can still get a representation on their own by calling getElement).

- Removes the automatic validation from the transformation loop as there is no guarantee that the transformation will be called once and we the warnings thrown are not related to the transformation.