### PR TITLE
Check array before use

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
@@ -123,7 +123,7 @@ abstract class ConfigurationSelectorRule extends Rule
 
         $results = $domXPath->query($xpath);
 
-        if ( is_array( $results ) ) {
+        if (false !== $results) {
             foreach ($results as $result) {
                 if ($result === $node) {
                     return true;

--- a/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ConfigurationSelectorRule.php
@@ -123,11 +123,14 @@ abstract class ConfigurationSelectorRule extends Rule
 
         $results = $domXPath->query($xpath);
 
-        foreach ($results as $result) {
-            if ($result === $node) {
-                return true;
+        if ( is_array( $results ) ) {
+            foreach ($results as $result) {
+                if ($result === $node) {
+                    return true;
+                }
             }
         }
+        
         return false;
     }
 


### PR DESCRIPTION
In some circumstances, `$results` is not an array which leads to PHP "invalid argument passed to foreach" errors. This fixes those by checking `$results` is in fact an array first.