### PR TITLE
Removed interactive.caption property from rule InteractiveRule

### DIFF
--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -142,10 +142,6 @@
             "interactive.iframe" : {
                 "type" : "children",
                 "selector" : "iframe"
-            },
-            "interactive.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
             }
         }
     }, {
@@ -170,10 +166,6 @@
             "interactive.iframe" : {
                 "type" : "children",
                 "selector" : "iframe"
-            },
-            "interactive.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
             }
         }
     }, {


### PR DESCRIPTION
This PR

* [x] Cleans up the configuration property **interactive.caption** from rules, since it is not being used anymore

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/361

