### PR TITLE
Compatibility with Jetpack plugin rules

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -16,6 +16,7 @@ class GetterFactory
     const TYPE_ELEMENT_GETTER = 'element';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
     const TYPE_EXISTS_GETTER = 'exists';
+    const TYPE_JSON_GETTER = 'json';
     const TYPE_XPATH_GETTER = 'xpath';
 
     /**
@@ -32,6 +33,7 @@ class GetterFactory
      * @see ElementGetter
      * @see NextSiblingGetter
      * @see ExistsGetter
+     * @see JSONGetter
      * @see XpathGetter
      *
      * @param string[] $getter_configuration that maps the properties for getter
@@ -47,6 +49,7 @@ class GetterFactory
             self::TYPE_ELEMENT_GETTER => ElementGetter::getClassName(),
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),
+            self::TYPE_JSON_GETTER => JSONGetter::getClassName(),
             self::TYPE_XPATH_GETTER => XpathGetter::getClassName()
         ];
 

--- a/src/Facebook/InstantArticles/Transformer/Getters/JSONGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/JSONGetter.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Getters;
+
+use Facebook\InstantArticles\Validators\Type;
+
+class JSONGetter extends ChildrenGetter
+{
+    /**
+     * @var string
+     */
+    protected $attribute;
+
+    public function createFrom($properties)
+    {
+        if (isset($properties['selector'])) {
+            $this->withSelector($properties['selector']);
+        }
+        if (isset($properties['attribute'])) {
+            $this->withAttribute($properties['attribute']);
+        }
+    }
+
+    /**
+     * @param string $attribute
+     *
+     * @return $this
+     */
+    public function withAttribute($attribute)
+    {
+        Type::enforce($attribute, Type::STRING);
+        $this->attribute = $attribute;
+
+        return $this;
+    }
+
+    public function get($node)
+    {
+        $content = null;
+
+        Type::enforce($node, 'DOMNode');
+        $elements = self::findAll($node, $this->selector);
+        if (!empty($elements) && $elements->item(0)) {
+            $element = $elements->item(0);
+            if ($this->attribute) {
+                $content = $element->getAttribute($this->attribute);
+            } else {
+                $content = $element->textContent;
+            }
+        }
+
+        if (!Type::isTextEmpty($content)) {
+            return json_decode($content, true);
+        }
+        return null;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Rules/Compat/JetpackSlideshowRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Compat/JetpackSlideshowRule.php
@@ -53,7 +53,7 @@ class JetpackSlideshowRule extends ConfigurationSelectorRule
         $gallery = $this->getProperty(self::PROPERTY_JETPACK_DATA_GALLERY, $node);
 
         if ($gallery && isset($gallery)) {
-            foreach($gallery as $gallery_image) {
+            foreach ($gallery as $gallery_image) {
                 // Constructs Image if it contains URL
                 if (!Type::isTextEmpty($gallery_image['src'])) {
                     $image = Image::create();

--- a/src/Facebook/InstantArticles/Transformer/Rules/Compat/JetpackSlideshowRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Compat/JetpackSlideshowRule.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Rules\Compat;
+
+use Facebook\InstantArticles\Transformer\Rules\ConfigurationSelectorRule;
+use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Elements\Image;
+use Facebook\InstantArticles\Elements\Caption;
+use Facebook\InstantArticles\Elements\Slideshow;
+
+class JetpackSlideshowRule extends ConfigurationSelectorRule
+{
+    const PROPERTY_JETPACK_DATA_GALLERY = 'jetpack.data-gallery';
+
+    public function getContextClass()
+    {
+        return InstantArticle::getClassName();
+    }
+
+    public static function create()
+    {
+        return new JetpackSlideshowRule();
+    }
+
+    public static function createFrom($configuration)
+    {
+        $slideshow_rule = self::create();
+        $slideshow_rule->withSelector($configuration['selector']);
+
+        $slideshow_rule->withProperties(
+            [
+                self::PROPERTY_JETPACK_DATA_GALLERY
+            ],
+            $configuration
+        );
+
+        return $slideshow_rule;
+    }
+
+    public function apply($transformer, $instant_article, $node)
+    {
+        // Builds the slideshow
+        $slideshow = Slideshow::create();
+        $instant_article->addChild($slideshow);
+
+        $gallery = $this->getProperty(self::PROPERTY_JETPACK_DATA_GALLERY, $node);
+
+        if ($gallery && isset($gallery)) {
+            foreach($gallery as $gallery_image) {
+                // Constructs Image if it contains URL
+                if (!Type::isTextEmpty($gallery_image['src'])) {
+                    $image = Image::create();
+                    $image->withURL($gallery_image['src']);
+
+                    // Constructs Caption element when present in the JSON
+                    if (!Type::isTextEmpty($gallery_image['caption'])) {
+                        $caption = Caption::create();
+                        $caption->appendText($gallery_image['caption']);
+                        $image->withCaption($caption);
+                    }
+                    $slideshow->addImage($image);
+                }
+            }
+        }
+
+        $transformer->transform($slideshow, $node);
+
+        return $instant_article;
+    }
+}

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -101,11 +101,9 @@
               <tr><td>Line 1 column 1</td>
           <td>Line 1 column 2</td>
         </tr>
-              <tr/>
               <tr><td>Line 2 column 1</td>
-            <td>Line 2 column 2</td>
-          </tr>
-              <tr/>
+          <td>Line 2 column 2</td>
+        </tr>
             </tbody>
           </table>
         </iframe>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -113,6 +113,39 @@
         <li>Some text on li before imgand after img</li>
         <li>Some text after img</li>
       </ul>
+      <figure class="op-slideshow">
+        <figure>
+          <img src="http://example.com/img0.jpg"/>
+        </figure>
+        <figure>
+          <img src="http://example.com/img1.jpg"/>
+        </figure>
+        <figure>
+          <img src="http://example.com/img2.jpg"/>
+          <figcaption>Image 2</figcaption>
+        </figure>
+        <figure>
+          <img src="http://example.com/img3.jpg"/>
+          <figcaption>Image 3</figcaption>
+        </figure>
+        <figure>
+          <img src="http://example.com/img4.jpg"/>
+        </figure>
+      </figure>
+      <figure class="op-slideshow">
+        <figure>
+          <img src="http://example.com/img1.jpg"/>
+          <figcaption> Image 1 </figcaption>
+        </figure>
+        <figure>
+          <img src="http://example.com/img2.jpg"/>
+          <figcaption> Image 2 </figcaption>
+        </figure>
+        <figure>
+          <img src="http://example.com/img3.jpg"/>
+          <figcaption> Image 3 </figcaption>
+        </figure>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -424,5 +424,81 @@
                 "attribute": "type"
             }
         }
+    },
+
+
+
+    {
+      "class" : "IgnoreRule",
+      "selector" : "p.jetpack-slideshow-noscript"
+    },
+    {
+      "class": "CaptionRule",
+      "selector" : "div.wp-caption-text"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-row"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.tiled-gallery p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-row p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-group p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-group"
+    },
+    {
+      "class": "ImageRule",
+      "selector" : "div.wp-caption",
+      "properties" : {
+          "image.url" : {
+              "type" : "string",
+              "selector" : "img",
+              "attribute": "src"
+          }
+      }
+    },
+    {
+      "class": "SlideshowImageRule",
+      "selector" : "div.tiled-gallery-item",
+      "properties" : {
+        "image.url" : {
+          "type" : "string",
+          "selector" : "img",
+          "attribute": "data-orig-file"
+        },
+        "caption.title" : {
+          "type" : "string",
+          "selector" : "div.tiled-gallery-caption"
+        }
+      }
+    },
+    {
+      "class": "SlideshowRule",
+      "selector" : "div.tiled-gallery"
+    },
+    {
+      "class": "Compat\\JetpackSlideshowRule",
+      "selector" : "div.jetpack-slideshow",
+      "properties": {
+        "jetpack.data-gallery": {
+          "type": "json",
+          "selector": "div.jetpack-slideshow",
+          "attribute": "data-gallery"
+        }
+      }
+    },
+    {
+      "class": "CaptionRule",
+      "selector" : "div.tiled-gallery-caption"
     }]
 }

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -59,11 +59,11 @@
         <tr>
           <td>Line 1 column 1</td>
           <td>Line 1 column 2</td>
+        </tr>
         <tr>
-          <tr>
-            <td>Line 2 column 1</td>
-            <td>Line 2 column 2</td>
-          <tr>
+          <td>Line 2 column 1</td>
+          <td>Line 2 column 2</td>
+        </tr>
       </tbody>
     </table>
     <ul>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -71,5 +71,56 @@
       <li>Some text on li before img<img src="http://example.com/image.jpg" width="600" height="360"/>and after img</li>
       <li><img src="http://example.com/image.jpg" width="600" height="360"/>Some text after img</li>
     </ul>
+    <p class="jetpack-slideshow-noscript robots-nocontent">This slideshow requires JavaScript.</p>
+    <div
+      class="slideshow-window jetpack-slideshow slideshow-black"
+      data-trans="fade" data-autostart="1"
+      data-gallery="[{&quot;src&quot;:&quot;http:\/\/example.com/img0.jpg&quot;,&quot;id&quot;:&quot;434&quot;,&quot;title&quot;:&quot;img0&quot;,&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;itemprop&quot;:&quot;image&quot;},{&quot;src&quot;:&quot;http:\/\/example.com\/img1.jpg&quot;,&quot;id&quot;:&quot;474&quot;,&quot;title&quot;:&quot;img1&quot;,&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;itemprop&quot;:&quot;image&quot;},{&quot;src&quot;:&quot;http:\/\/example.com\/img2.jpg&quot;,&quot;id&quot;:&quot;470&quot;,&quot;title&quot;:&quot;img2&quot;,&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;Image 2&quot;,&quot;itemprop&quot;:&quot;image&quot;},{&quot;src&quot;:&quot;http:\/\/example.com\/img3.jpg&quot;,&quot;id&quot;:&quot;466&quot;,&quot;title&quot;:&quot;Image 3&quot;,&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;Image 3&quot;,&quot;itemprop&quot;:&quot;image&quot;},{&quot;src&quot;:&quot;http:\/\/example.com\/img4.jpg&quot;,&quot;id&quot;:&quot;462&quot;,&quot;title&quot;:&quot;img4&quot;,&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;itemprop&quot;:&quot;image&quot;}]"
+      itemscope itemtype="http://schema.org/ImageGallery">
+    </div>
+
+    <div class="tiled-gallery type-rectangular tiled-gallery-unresized" >
+      <div class="gallery-row">
+        <div class="gallery-group images-1">
+          <div class="tiled-gallery-item tiled-gallery-item-large">
+            <a href="http://www.diegoquinteiro.com/15-razoes-para-ser-contra-o-impeachment/forum/">
+              <meta itemprop="width" content="318">
+              <meta itemprop="height" content="211">
+              <img data-orig-file="http://example.com/img1.jpg"
+              data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="Forum" data-image-description="" data-medium-file="http://http://example.com/img1.jpg" data-large-file="http://example.com/img1.jpg" src="http://example.com/img1.jpg?resize=318%2C211"
+              width="318" height="211" data-original-width="318" data-original-height="211" title="Forum" alt="riots" style="width: 318px; height: 211px;" />
+            </a>
+            <div class="tiled-gallery-caption" itemprop="caption description"> Image 1 </div>
+            </p>
+          </div>
+          </p>
+        </div>
+        <p> <!-- close group -->
+        <div class="gallery-group images-2">
+          <div class="tiled-gallery-item tiled-gallery-item-small" itemprop="associatedMedia">
+            <a href="http://example.com/link" border="0" itemprop="url">
+              <meta itemprop="width" content="174">
+              <meta itemprop="height" content="109">
+              <img data-attachment-id="519" data-orig-file="http://example.com/img2.jpg" data-orig-size="2078,1310" data-comments-opened="" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="Chaplin &#8211; Fábrica" data-image-description="" data-medium-file="http://example.com/img2.jpg" data-large-file="http://example.com/img2.jpg" src="http://example.com/img2.jpg?resize=174%2C109" width="174" height="109" data-original-width="174" data-original-height="109" itemprop="http://schema.org/image" title="Image Title" alt="chaplin" style="width: 174px; height: 109px;" />
+            </a>
+            <div class="tiled-gallery-caption" itemprop="caption description"> Image 2 </div>
+            </p>
+          </div>
+          <div class="tiled-gallery-item tiled-gallery-item-small" itemprop="associatedMedia">
+            <a href="http://example.com/link" border="0" itemprop="url">
+              <meta itemprop="width" content="174">
+              <meta itemprop="height" content="98">
+              <img data-attachment-id="532" data-orig-file="http://example.com/img3.jpg" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="highlight image" data-image-description="" data-medium-file="http://www.diegoquinteiro.com/wp-content/uploads/2016/06/highlight-image-300x169.jpg" data-large-file="http://www.diegoquinteiro.com/wp-content/uploads/2016/06/highlight-image-1024x576.jpg" src="http://i1.wp.com/www.diegoquinteiro.com/wp-content/uploads/2016/06/highlight-image.jpg?resize=174%2C98" width="174" height="98" data-original-width="174" data-original-height="98" itemprop="http://schema.org/image" title="highlight image" alt="Dog cat" style="width: 174px; height: 98px;" />
+            </a>
+            <div class="tiled-gallery-caption" itemprop="caption description"> Image 3 </div>
+            </p>
+          </div>
+          </p>
+        </div>
+        <p> <!-- close group -->
+      </div>
+      <p> <!-- close row -->
+    </div>
+
   </body>
 </html>


### PR DESCRIPTION
This PR
Will have the /Compat rules moved from it when WordPress unit tests are ok. While this is not true, this will be landed here.

* [x] Created compat layer to the plugin Jetpack (slideshow, tiled gallery, video)
* [x] Adds test unit cases for the new cases
* [x] Creates the configuration rules.

Related to https://github.com/Automattic/facebook-instant-articles-wp/pull/374.
Fixes #.
