### PR TITLE
Added getter for canonicalURL

### DIFF
--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -268,6 +268,14 @@ class InstantArticle extends Element implements Container, InstantArticleInterfa
     }
 
     /**
+     * @return string canonicalURL from the InstantArticle
+     */
+    public function getCanonicalURL()
+    {
+        return $this->canonicalURL;
+    }
+
+    /**
      * @return Header header element from the InstantArticle
      */
     public function getHeader()


### PR DESCRIPTION
This PR

* [x] Adds a missing getter for the canonicalURL property in InstantArticle element.

Related to https://github.com/Automattic/facebook-instant-articles-wp/pull/375

