### PR TITLE
Instagram embed

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -37,11 +37,28 @@ abstract class Element
         $document->formatOutput = $formatted;
         $element = $this->toDOMElement($document);
         $document->appendChild($element);
-        $rendered = $doctype.$document->saveXML($element);
+        $rendered = $doctype.$document->saveXML($element, LIBXML_NOEMPTYTAG);
 
         // We can't currently use DOMDocument::saveHTML, because it doesn't produce proper HTML5 markup, so we have to strip CDATA enclosures
         // TODO Consider replacing this workaround with a parent class for elements that will be rendered and in this class use the `srcdoc` attribute to output the (escaped) markup
         $rendered = preg_replace('/<!\[CDATA\[(.*?)\]\]>/is', '$1', $rendered);
+        // Fix void HTML5 elements (these can't be closed like in XML)
+        $rendered = str_replace('></area>', '/>', $rendered);
+        $rendered = str_replace('></base>', '/>', $rendered);
+        $rendered = str_replace('></br>', '/>', $rendered);
+        $rendered = str_replace('></col>', '/>', $rendered);
+        $rendered = str_replace('></command>', '/>', $rendered);
+        $rendered = str_replace('></embed>', '/>', $rendered);
+        $rendered = str_replace('></hr>', '/>', $rendered);
+        $rendered = str_replace('></img>', '/>', $rendered);
+        $rendered = str_replace('></input>', '/>', $rendered);
+        $rendered = str_replace('></keygen>', '/>', $rendered);
+        $rendered = str_replace('></link>', '/>', $rendered);
+        $rendered = str_replace('></meta>', '/>', $rendered);
+        $rendered = str_replace('></param>', '/>', $rendered);
+        $rendered = str_replace('></source>', '/>', $rendered);
+        $rendered = str_replace('></track>', '/>', $rendered);
+        $rendered = str_replace('></wbr>', '/>', $rendered);
 
         return $rendered;
     }

--- a/src/Facebook/InstantArticles/Transformer/Getters/ChildrenGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ChildrenGetter.php
@@ -8,6 +8,9 @@
  */
 namespace Facebook\InstantArticles\Transformer\Getters;
 
+use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Transformer\Transformer;
+
 class ChildrenGetter extends ElementGetter
 {
     public function get($node)
@@ -16,7 +19,8 @@ class ChildrenGetter extends ElementGetter
         if ($element) {
             $fragment = $element->ownerDocument->createDocumentFragment();
             foreach ($element->childNodes as $child) {
-                $fragment->appendChild($child->cloneNode(true));
+                Transformer::markAsProcessed($child);
+                $fragment->appendChild(Transformer::cloneNode($child));
             }
             if ($fragment->hasChildNodes()) {
                 return $fragment;

--- a/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class ElementGetter extends AbstractGetter
@@ -53,7 +54,8 @@ class ElementGetter extends AbstractGetter
     {
         $elements = self::findAll($node, $this->selector);
         if (!empty($elements)) {
-            return $elements->item(0);
+            Transformer::markAsProcessed($elements->item(0));
+            return Transformer::cloneNode($elements->item(0));
         }
         return null;
     }

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -15,9 +15,11 @@ class GetterFactory
     const TYPE_CHILDREN_GETTER = 'children';
     const TYPE_ELEMENT_GETTER = 'element';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
+    const TYPE_NEXTSIBLINGELEMENT_GETTER = 'sibling-element';
     const TYPE_EXISTS_GETTER = 'exists';
     const TYPE_JSON_GETTER = 'json';
     const TYPE_XPATH_GETTER = 'xpath';
+    const TYPE_MULTIPLEELEMENTS_GETTER = 'multiple';
 
     /**
      * Creates an Getter class.
@@ -48,9 +50,11 @@ class GetterFactory
             self::TYPE_CHILDREN_GETTER => ChildrenGetter::getClassName(),
             self::TYPE_ELEMENT_GETTER => ElementGetter::getClassName(),
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
+            self::TYPE_NEXTSIBLINGELEMENT_GETTER => NextSiblingElementGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),
             self::TYPE_JSON_GETTER => JSONGetter::getClassName(),
-            self::TYPE_XPATH_GETTER => XpathGetter::getClassName()
+            self::TYPE_XPATH_GETTER => XpathGetter::getClassName(),
+            self::TYPE_MULTIPLEELEMENTS_GETTER => MultipleElementsGetter::getClassName()
         ];
 
         $class = $getter_configuration['type'];

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -15,7 +15,7 @@ class GetterFactory
     const TYPE_CHILDREN_GETTER = 'children';
     const TYPE_ELEMENT_GETTER = 'element';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
-    const TYPE_NEXTSIBLINGELEMENT_GETTER = 'sibling-element';
+    const TYPE_NEXTSIBLINGELEMENT_GETTER = 'next-sibling-element-of';
     const TYPE_EXISTS_GETTER = 'exists';
     const TYPE_JSON_GETTER = 'json';
     const TYPE_XPATH_GETTER = 'xpath';

--- a/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class MultipleElementsGetter extends AbstractGetter
@@ -30,9 +31,9 @@ class MultipleElementsGetter extends AbstractGetter
     {
         $fragment = $node->ownerDocument->createDocumentFragment();
         foreach ($this->children as $child) {
-            $single_node = $child->get($node);
-            if (Type::is($single_node, 'DOMNode')) {
-                $fragment->appendChild($single_node->cloneNode(true));
+            $cloned_node = $child->get($node);
+            if (Type::is($cloned_node, 'DOMNode')) {
+                $fragment->appendChild($cloned_node);
             }
         }
         if ($fragment->hasChildNodes()) {

--- a/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
@@ -18,7 +18,6 @@ class MultipleElementsGetter extends AbstractGetter
      */
     protected $children = [];
 
-    // TODO: make it static
     public function createFrom($properties)
     {
         foreach ($properties['children'] as $getter_configuration) {

--- a/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Getters;
+
+use Facebook\InstantArticles\Validators\Type;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+class MultipleElementsGetter extends AbstractGetter
+{
+    /**
+     * @var Getters
+     */
+    protected $children = [];
+
+    // TODO: make it static
+    public function createFrom($properties)
+    {
+        foreach ($properties['children'] as $getter_configuration) {
+            $this->children[] = GetterFactory::create($getter_configuration);
+        }
+        return $this;
+    }
+
+    public function get($node)
+    {
+        $fragment = $node->ownerDocument->createDocumentFragment();
+        foreach ($this->children as $child) {
+            $single_node = $child->get($node);
+            if (Type::is($single_node, 'DOMNode')) {
+                $fragment->appendChild($single_node->cloneNode(true));
+            }
+        }
+        if ($fragment->hasChildNodes()) {
+            return $fragment;
+        }
+        return null;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingElementGetter.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Getters;
 
 use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Transformer\Transformer;
 
 class NextSiblingElementGetter extends ElementGetter
 {
@@ -32,8 +33,9 @@ class NextSiblingElementGetter extends ElementGetter
                 $element = $element->nextSibling;
             } while ($element !== null && !Type::is($element, 'DOMElement'));
 
-            if ($element) {
-                return $element;
+            if ($element && Type::is($element, 'DOMElement')) {
+                Transformer::markAsProcessed($element);
+                return Transformer::cloneNode($element);
             }
         }
         return null;

--- a/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/NextSiblingElementGetter.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Getters;
+
+use Facebook\InstantArticles\Validators\Type;
+
+class NextSiblingElementGetter extends ElementGetter
+{
+    public function createFrom($properties)
+    {
+        if (isset($properties['selector'])) {
+            $this->withSelector($properties['selector']);
+        }
+        if (isset($properties['attribute'])) {
+            $this->withAttribute($properties['attribute']);
+        }
+    }
+
+    public function get($node)
+    {
+        Type::enforce($node, 'DOMNode');
+        $elements = self::findAll($node, $this->selector);
+        if (!empty($elements) && $elements->item(0)) {
+            $element = $elements->item(0);
+            do {
+                $element = $element->nextSibling;
+            } while ($element !== null && !Type::is($element, 'DOMElement'));
+
+            if ($element) {
+                return $element;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -47,6 +47,47 @@ class Transformer
     private $instantArticle;
 
     /**
+     * Flag attribute added to elements processed by a getter, so they
+     * are not processed again by other rules.
+     */
+    const INSTANT_ARTICLES_PARSED_FLAG = 'data-instant-articles-element-processed';
+
+    /**
+     * Clones a node for appending to raw-html containing Elements like Interactive.
+     *
+     * @param DOMNode $node The node to clone
+     * @return DOMNode The cloned node.
+     */
+    public static function cloneNode($node) {
+        $clone = $node->cloneNode(true);
+        if (Type::is($clone, 'DOMElement') && $clone->hasAttribute(self::INSTANT_ARTICLES_PARSED_FLAG)) {
+            $clone->removeAttribute(self::INSTANT_ARTICLES_PARSED_FLAG);
+        }
+        return $clone;
+    }
+
+    /**
+     * Marks a node as processed.
+     *
+     * @param DOMElement $node The node to clone
+     */
+    public static function markAsProcessed($node) {
+        if (Type::is($node, 'DOMElement')) {
+            $node->setAttribute(self::INSTANT_ARTICLES_PARSED_FLAG, true);
+        }
+    }
+
+    /**
+     * Returns whether a node is processed
+     *
+     * @param DOMNode $node The node to clone
+     */
+    protected static function isProcessed($node) {
+        return Type::is($node, 'DOMElement') && $node->getAttribute(self::INSTANT_ARTICLES_PARSED_FLAG);
+    }
+
+
+    /**
      * Gets all types a given class is, including itself, parent classes and interfaces.
      *
      * @param string $className - the name of the className
@@ -147,6 +188,9 @@ class Transformer
         $current_context = $context;
         if ($node->hasChildNodes()) {
             foreach ($node->childNodes as $child) {
+                if (self::isProcessed($child)) {
+                    continue;
+                }
                 $matched = false;
                 $log->debug("===========================");
                 $log->debug($child->ownerDocument->saveHtml($child));

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -58,7 +58,8 @@ class Transformer
      * @param DOMNode $node The node to clone
      * @return DOMNode The cloned node.
      */
-    public static function cloneNode($node) {
+    public static function cloneNode($node)
+    {
         $clone = $node->cloneNode(true);
         if (Type::is($clone, 'DOMElement') && $clone->hasAttribute(self::INSTANT_ARTICLES_PARSED_FLAG)) {
             $clone->removeAttribute(self::INSTANT_ARTICLES_PARSED_FLAG);
@@ -71,7 +72,8 @@ class Transformer
      *
      * @param DOMElement $node The node to clone
      */
-    public static function markAsProcessed($node) {
+    public static function markAsProcessed($node)
+    {
         if (Type::is($node, 'DOMElement')) {
             $node->setAttribute(self::INSTANT_ARTICLES_PARSED_FLAG, true);
         }
@@ -82,7 +84,8 @@ class Transformer
      *
      * @param DOMNode $node The node to clone
      */
-    protected static function isProcessed($node) {
+    protected static function isProcessed($node)
+    {
         return Type::is($node, 'DOMElement') && $node->getAttribute(self::INSTANT_ARTICLES_PARSED_FLAG);
     }
 

--- a/src/Facebook/InstantArticles/Transformer/Warnings/InvalidSelector.php
+++ b/src/Facebook/InstantArticles/Transformer/Warnings/InvalidSelector.php
@@ -55,11 +55,19 @@ class InvalidSelector
      */
     public function __toString()
     {
-        $reflection = new \ReflectionClass(get_class($this->context));
-        $class_name = $reflection->getShortName();
+        if (isset($this->context)) {
+            $reflection = new \ReflectionClass(get_class($this->context));
+            $class_name = $reflection->getShortName();
+        } else {
+            $class_name = 'no context provided';
+        }
 
-        $reflection = new \ReflectionClass(get_class($this->rule));
-        $rule_name = $reflection->getShortName();
+        if (isset($this->rule)) {
+            $reflection = new \ReflectionClass(get_class($this->rule));
+            $rule_name = $reflection->getShortName();
+        } else {
+            $rule_name = 'no rule provided';
+        }
 
         $has_properties = false;
         $str_properties = '';

--- a/tests/Facebook/InstantArticles/Transformer/CMS/WPTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/WPTransformerTest.php
@@ -75,4 +75,23 @@ class WPTransformerTest extends \PHPUnit_Framework_TestCase
         // there must be 3 warnings related to <img> inside <li> that is not supported by IA
         $this->assertEquals(3, count($transformer->getWarnings()));
     }
+
+    public function testTitleTransformedWithBold()
+    {
+        $transformer = new Transformer();
+        $json_file = file_get_contents(__DIR__ . '/wp-rules.json');
+        $transformer->loadRules($json_file);
+
+        $title_html_string = '<?xml encoding="utf-8" ?><h1>Title <b>in bold</b></h1>';
+
+        libxml_use_internal_errors(true);
+        $document = new \DOMDocument();
+        $document->loadHtml($title_html_string);
+        libxml_use_internal_errors(false);
+
+        $header = Header::create();
+        $transformer->transform($header, $document);
+
+        $this->assertEquals('<h1>Title <b>in bold</b></h1>', $header->getTitle()->render());
+    }
 }

--- a/tests/Facebook/InstantArticles/Transformer/CMS/WPTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/WPTransformerTest.php
@@ -73,7 +73,8 @@ class WPTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
         // there must be 3 warnings related to <img> inside <li> that is not supported by IA
-        $this->assertEquals(3, count($transformer->getWarnings()));
+        // And 1 warning related to the getter
+        $this->assertEquals(4, count($transformer->getWarnings()));
     }
 
     public function testTitleTransformedWithBold()

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -151,7 +151,7 @@
           <blockquote class="instagram-media" data-instgrm-captioned="" data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
       <div style="padding:8px;">
         <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:62.5% 0; text-align:center; width:100%;">
-          <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"/>
+          <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div>
         </div>
         <p style=" margin:8px 0 0 0; padding:0 4px;">
           <a href="https://www.instagram.com/p/BAXbKP1POQe/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">ð¸ @natthaponwuttipetch</a>
@@ -160,6 +160,7 @@
           A photo posted by Ann Hathairat Vidhyaphum (@annvidh) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-01-10T16:56:06+00:00">Jan 10, 2016 at 8:56am PST</time></p>
       </div>
     </blockquote>
+          <script async="" defer="defer" src="//platform.instagram.com/en_US/embeds.js"></script>
         </iframe>
       </figure>
     </article>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -167,6 +167,12 @@
         <img src="http://example.com/img.jpg"/>
         <figcaption>blue eyes</figcaption>
       </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+      <h1>Sibling content</h1>
+      <div>sibling body</div></iframe>
+      </figure>
+      <p>Standard paragraph that <b>shouldn't</b> lie within the interactive block.</p>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -146,6 +146,22 @@
           <figcaption> Image 3 </figcaption>
         </figure>
       </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <blockquote class="instagram-media" data-instgrm-captioned="" data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
+      <div style="padding:8px;">
+        <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:62.5% 0; text-align:center; width:100%;">
+          <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"/>
+        </div>
+        <p style=" margin:8px 0 0 0; padding:0 4px;">
+          <a href="https://www.instagram.com/p/BAXbKP1POQe/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">ð¸ @natthaponwuttipetch</a>
+        </p>
+        <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">
+          A photo posted by Ann Hathairat Vidhyaphum (@annvidh) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-01-10T16:56:06+00:00">Jan 10, 2016 at 8:56am PST</time></p>
+      </div>
+    </blockquote>
+        </iframe>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -125,11 +125,22 @@
         "selector" : "blockquote.instagram-media",
         "properties" : {
             "interactive.iframe" : {
-                "type" : "element",
-                "selector" : "blockquote"
+                "type" : "multiple",
+                "children": [
+                    {
+                        "type": "element",
+                        "selector": "blockquote"
+                    }, {
+                        "type": "sibling-element",
+                        "selector": "blockquote"
+                    }
+                ]
             }
         }
-    },{
+    }, {
+        "class": "IgnoreRule",
+        "selector" : "script"
+    }, {
         "class": "InteractiveRule",
         "selector" : "iframe",
         "properties" : {

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -122,6 +122,15 @@
         "selector" : "h3,h4,h5,h6"
     }, {
         "class": "InteractiveRule",
+        "selector" : "blockquote.instagram-media",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "element",
+                "selector" : "blockquote"
+            }
+        }
+    },{
+        "class": "InteractiveRule",
         "selector" : "iframe",
         "properties" : {
             "interactive.url" : {

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -530,6 +530,26 @@
                 "attribute": "src"
             }
         }
+    },
+
+    {
+        "class": "InteractiveRule",
+        "selector" : "iframe.sibling",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "multiple",
+                "children": [
+                    {
+                        "type": "children",
+                        "selector": "iframe"
+                    }, {
+                        "type": "next-sibling-element-of",
+                        "selector": "iframe",
+                        "sibling.selector": "script"
+                    }
+                ]
+            }
+        }
     }
   ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -131,15 +131,12 @@
                         "type": "element",
                         "selector": "blockquote"
                     }, {
-                        "type": "sibling-element",
+                        "type": "next-sibling-element-of",
                         "selector": "blockquote"
                     }
                 ]
             }
         }
-    }, {
-        "class": "IgnoreRule",
-        "selector" : "script"
     }, {
         "class": "InteractiveRule",
         "selector" : "iframe",

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -142,5 +142,10 @@
         <figcaption class="wp-caption-text">blue eyes</figcaption>
       </figure>
     </p>
+    <iframe class="sibling">
+      <h1>Sibling content</h1>
+      <div>sibling body</div></iframe>
+    <script src="//sibling.com/brother.js"></script>
+    <p>Standard paragraph that <b>shouldn't</b> lie within the interactive block.</p>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -121,6 +121,18 @@
       </div>
       <p> <!-- close row -->
     </div>
-
+    <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
+      <div style="padding:8px;">
+        <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:62.5% 0; text-align:center; width:100%;">
+          <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div>
+        </div>
+        <p style=" margin:8px 0 0 0; padding:0 4px;">
+          <a href="https://www.instagram.com/p/BAXbKP1POQe/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">📸 @natthaponwuttipetch</a>
+        </p>
+        <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">
+          A photo posted by Ann Hathairat Vidhyaphum (@annvidh) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-01-10T16:56:06+00:00">Jan 10, 2016 at 8:56am PST</time>
+        </p>
+      </div>
+    </blockquote>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -134,5 +134,6 @@
         </p>
       </div>
     </blockquote>
+    <script async defer src="//platform.instagram.com/en_US/embeds.js"></script>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -28,7 +28,7 @@
       <p>Curabitur vulputate odio eu justo <i>venenatis</i>, a pretium orci placerat. Nam sed neque quis eros vestibulum mattis. Donec vitae mi egestas, laoreet massa et, fringilla libero.</p>
       <figure class="op-interactive">
         <iframe>
-            <iframe width="620" height="349" src="https://www.youtube.com/embed/s1tN0ggNreA?feature=oembed" frameborder="0" allowfullscreen=""/>
+            <iframe width="620" height="349" src="https://www.youtube.com/embed/s1tN0ggNreA?feature=oembed" frameborder="0" allowfullscreen=""></iframe>
         </iframe>
       </figure>
       <figure class="op-interactive">

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -93,23 +93,4 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $transformer->resetRules();
         $this->assertEquals([], $transformer->getRules());
     }
-
-    public function testTitleTransformedWithBold()
-    {
-        $transformer = new Transformer();
-        $json_file = file_get_contents(__DIR__ . '/CMS/wp-rules.json');
-        $transformer->loadRules($json_file);
-
-        $title_html_string = '<?xml encoding="utf-8" ?><h1>Title <b>in bold</b></h1>';
-
-        libxml_use_internal_errors(true);
-        $document = new \DOMDocument();
-        $document->loadHtml($title_html_string);
-        libxml_use_internal_errors(false);
-
-        $header = Header::create();
-        $transformer->transform($header, $document);
-
-        $this->assertEquals('<h1>Title <b>in bold</b></h1>', $header->getTitle()->render());
-    }
 }


### PR DESCRIPTION
This PR

* [x] Adds two new getters for multiple elements and for sibling elements
* [x] Adds proper serialization of string tags (not self-closing).
* [x] Updates WordPress example rules to include up to date IG embed matching
* [x] Guarantees no silently fail when selecting any sibling element. 
* [ ] Migrate all embed rules to use this sibling selector