### PR TITLE
Implemented compat for the get-the-image plugin

### DIFF
--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -146,6 +146,10 @@
           <figcaption> Image 3 </figcaption>
         </figure>
       </figure>
+      <figure>
+        <img src="http://example.com/img.jpg"/>
+        <figcaption>blue eyes</figcaption>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -500,5 +500,19 @@
     {
       "class": "CaptionRule",
       "selector" : "div.tiled-gallery-caption"
-    }]
+    },
+
+
+    {
+        "class": "ImageInsideParagraphRule",
+        "selector": "figure.wp-caption",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            }
+        }
+    }
+  ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -121,6 +121,13 @@
       </div>
       <p> <!-- close row -->
     </div>
+    <p>
+      <figure style="width: 1280px" class="wp-caption alignnone">
+        <img src="http://example.com/img.jpg" width="1280" height="740" class />
+        <br />
+        <figcaption class="wp-caption-text">blue eyes</figcaption>
+      </figure>
+    </p>
 
   </body>
 </html>


### PR DESCRIPTION
This PR

* [x] Adds test case for the expected markup
* [x] Adds rules for the expected markup 

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/381

