### PR TITLE
Add HardcodedElementGetter

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/FragmentGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/FragmentGetter.php
@@ -12,7 +12,7 @@ use Facebook\InstantArticles\Validators\Type;
 use Facebook\InstantArticles\Transformer\Transformer;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
-class HardcodedElementGetter extends AbstractGetter
+class FragmentGetter extends AbstractGetter
 {
     /**
      * @var string

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -14,7 +14,7 @@ class GetterFactory
     const TYPE_INTEGER_GETTER = 'int';
     const TYPE_CHILDREN_GETTER = 'children';
     const TYPE_ELEMENT_GETTER = 'element';
-    const TYPE_HARDCODED_GETTER = 'hardcoded';
+    const TYPE_FRAGMENT_GETTER = 'fragment';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
     const TYPE_NEXTSIBLINGELEMENT_GETTER = 'next-sibling-element-of';
     const TYPE_EXISTS_GETTER = 'exists';
@@ -50,7 +50,7 @@ class GetterFactory
             self::TYPE_INTEGER_GETTER => IntegerGetter::getClassName(),
             self::TYPE_CHILDREN_GETTER => ChildrenGetter::getClassName(),
             self::TYPE_ELEMENT_GETTER => ElementGetter::getClassName(),
-            self::TYPE_HARDCODED_GETTER => HardcodedElementGetter::getClassName(),
+            self::TYPE_FRAGMENT_GETTER => FragmentGetter::getClassName(),
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
             self::TYPE_NEXTSIBLINGELEMENT_GETTER => NextSiblingElementGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -14,6 +14,7 @@ class GetterFactory
     const TYPE_INTEGER_GETTER = 'int';
     const TYPE_CHILDREN_GETTER = 'children';
     const TYPE_ELEMENT_GETTER = 'element';
+    const TYPE_HARDCODED_GETTER = 'hardcoded';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
     const TYPE_NEXTSIBLINGELEMENT_GETTER = 'next-sibling-element-of';
     const TYPE_EXISTS_GETTER = 'exists';
@@ -49,6 +50,7 @@ class GetterFactory
             self::TYPE_INTEGER_GETTER => IntegerGetter::getClassName(),
             self::TYPE_CHILDREN_GETTER => ChildrenGetter::getClassName(),
             self::TYPE_ELEMENT_GETTER => ElementGetter::getClassName(),
+            self::TYPE_HARDCODED_GETTER => HardcodedElementGetter::getClassName(),
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
             self::TYPE_NEXTSIBLINGELEMENT_GETTER => NextSiblingElementGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),

--- a/src/Facebook/InstantArticles/Transformer/Getters/HardcodedElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/HardcodedElementGetter.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Getters;
+
+use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Transformer\Transformer;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+class HardcodedElementGetter extends AbstractGetter
+{
+    /**
+     * @var string
+     */
+    protected $fragment;
+
+    public function createFrom($properties)
+    {
+        return $this->withFragment($properties['fragment']);
+    }
+
+    /**
+     * @param string $fragment
+     *
+     * @return $this
+     */
+    public function withFragment($fragment)
+    {
+        Type::enforce($fragment, Type::STRING);
+        $this->fragment = $fragment;
+
+        return $this;
+    }
+
+    public function get($node)
+    {
+        $fragment = $node->ownerDocument->createDocumentFragment();
+        $is_valid_markup = @$fragment->appendXML($this->fragment);
+        if ($is_valid_markup) {
+          return $fragment;
+        }
+        return null;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Getters/HardcodedElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/HardcodedElementGetter.php
@@ -42,7 +42,7 @@ class HardcodedElementGetter extends AbstractGetter
         $fragment = $node->ownerDocument->createDocumentFragment();
         $is_valid_markup = @$fragment->appendXML($this->fragment);
         if ($is_valid_markup) {
-          return $fragment;
+            return $fragment;
         }
         return null;
     }

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -173,6 +173,12 @@
       <div>sibling body</div></iframe>
       </figure>
       <p>Standard paragraph that <b>shouldn't</b> lie within the interactive block.</p>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <p>Extra markup</p>
+          <div class="fb-post" data-href="https://www.facebook.com/some-page/posts/some-post"></div>
+        </iframe>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -268,6 +268,24 @@
             }
         }
     }, {
+        "class": "InteractiveRule",
+        "selector" : "div.fb-post",
+        "properties" : {
+            "interactive.iframe" : {
+                "type": "multiple",
+                "children": [
+                    {
+                        "type": "hardcoded",
+                        "fragment": "<p>Extra markup</p>"
+                    },
+                    {
+                        "type" : "element",
+                        "selector" : "div.fb-post"
+                    }
+                ]
+            }
+        }
+    }, {
         "class": "InteractiveInsideParagraphRule",
         "selector" : "iframe",
         "properties" : {

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -275,7 +275,7 @@
                 "type": "multiple",
                 "children": [
                     {
-                        "type": "hardcoded",
+                        "type": "fragment",
                         "fragment": "<p>Extra markup</p>"
                     },
                     {

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -147,5 +147,6 @@
       <div>sibling body</div></iframe>
     <script src="//sibling.com/brother.js"></script>
     <p>Standard paragraph that <b>shouldn't</b> lie within the interactive block.</p>
+    <div class="fb-post" data-href="https://www.facebook.com/some-page/posts/some-post"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a new getter allowing the output to contain markup not originally in the source. These hardcoded snippets are intended to be used with the MultipleElementGetter to append or prepend code to embeds.