### PR TITLE
Fix Caption inside <p> tag

### DIFF
--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-ia.xml
@@ -193,6 +193,10 @@
           <figcaption>Caption img 3</figcaption>
         </figure>
       </figure>
+      <figure>
+        <img src="http://example.com/image.jpg"/>
+        <figcaption>caption</figcaption>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json
@@ -432,8 +432,10 @@
     }, {
         "class": "CaptionRule",
         "selector" : "figcaption"
-    },
-    {
+    }, {
+      "class": "CaptionRule",
+      "selector" : "p.wp-caption-text"
+    }, {
         "class": "ImageRule",
         "selector" : "figure",
         "properties" : {

--- a/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/CMS/wp.html
@@ -213,6 +213,9 @@
         </div>
       </div>
     </div>
-
+    <div id="attachment_22553" style="width: 800px" class="wp-caption alignnone">
+      <img class="wp-image-22553 size-large" src="http://example.com/image.jpg" alt="alt text" width="800" height="552" srcset="http://example.com/image-800.jpg 800w, http://example.com/image-400.jpg 400w, http://example.com/image-768.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" />
+      <p class="wp-caption-text">caption</p>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
This PR

* [x] Fixes caption for regular images using paragraphs as container for the caption content

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/205