### PR TITLE
Adds ConstantGetter: 'constant'

### DIFF
--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -213,24 +213,30 @@
             {
                 "class": "TimeRule",
                 "selector" : "time.op-modified",
-                "article.time_type": "op-modified",
                 "properties" : {
                     "article.time" : {
                         "type" : "string",
                         "selector" : "time",
                         "attribute": "datetime"
+                    },
+                    "article.datetype": {
+                        "type": "constant",
+                        "value": "op-modified"
                     }
                 }
             },
             {
                 "class": "TimeRule",
                 "selector" : "time.op-published",
-                "article.time_type": "op-published",
                 "properties" : {
                     "article.time" : {
                         "type" : "string",
                         "selector" : "time",
                         "attribute": "datetime"
+                    },
+                    "article.datetype": {
+                        "type": "constant",
+                        "value": "op-published"
                     }
                 }
             },

--- a/src/Facebook/InstantArticles/Transformer/Getters/ConstantGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ConstantGetter.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Getters;
+
+use Facebook\InstantArticles\Validators\Type;
+
+class ConstantGetter extends AbstractGetter
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    public function createFrom($properties)
+    {
+        return $this->withValue($properties['value']);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function withValue($value)
+    {
+        Type::enforce($value, Type::STRING);
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function get($node)
+    {
+        return $this->value;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/GetterFactory.php
@@ -14,6 +14,7 @@ class GetterFactory
     const TYPE_INTEGER_GETTER = 'int';
     const TYPE_CHILDREN_GETTER = 'children';
     const TYPE_ELEMENT_GETTER = 'element';
+    const TYPE_CONSTANT_GETTER = 'constant';
     const TYPE_FRAGMENT_GETTER = 'fragment';
     const TYPE_NEXTSIBLING_GETTER = 'sibling';
     const TYPE_NEXTSIBLINGELEMENT_GETTER = 'next-sibling-element-of';
@@ -34,6 +35,7 @@ class GetterFactory
      * @see ChildrenGetter
      * @see IntegerGetter
      * @see ElementGetter
+     * @see ConstantGetter
      * @see NextSiblingGetter
      * @see ExistsGetter
      * @see JSONGetter
@@ -51,6 +53,7 @@ class GetterFactory
             self::TYPE_CHILDREN_GETTER => ChildrenGetter::getClassName(),
             self::TYPE_ELEMENT_GETTER => ElementGetter::getClassName(),
             self::TYPE_FRAGMENT_GETTER => FragmentGetter::getClassName(),
+            self::TYPE_CONSTANT_GETTER => ConstantGetter::getClassName(),
             self::TYPE_NEXTSIBLING_GETTER => NextSiblingGetter::getClassName(),
             self::TYPE_NEXTSIBLINGELEMENT_GETTER => NextSiblingElementGetter::getClassName(),
             self::TYPE_EXISTS_GETTER => ExistsGetter::getClassName(),

--- a/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
@@ -14,7 +14,8 @@ use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class TimeRule extends ConfigurationSelectorRule
 {
-    const PROPERTY_TIME_TYPE = 'article.time_type';
+    const PROPERTY_TIME_TYPE_DEPRECATED = 'article.time_type';
+    const PROPERTY_DATETIME_TYPE = 'article.datetype';
     const PROPERTY_TIME = 'article.time';
 
     private $type = Time::PUBLISHED;
@@ -34,13 +35,17 @@ class TimeRule extends ConfigurationSelectorRule
         $time_rule = self::create();
         $time_rule->withSelector($configuration['selector']);
 
-        $time_rule->withProperty(
-            self::PROPERTY_TIME,
-            self::retrieveProperty($configuration, self::PROPERTY_TIME)
+        $time_rule->withProperties(
+            [
+                self::PROPERTY_TIME,
+                self::PROPERTY_DATETIME_TYPE
+            ],
+            $configuration
         );
 
-        if (isset($configuration[self::PROPERTY_TIME_TYPE])) {
-            $time_rule->type = $configuration[self::PROPERTY_TIME_TYPE];
+        // Just for retrocompatibility - issue #172
+        if (isset($configuration[self::PROPERTY_TIME_TYPE_DEPRECATED])) {
+            $time_rule->type = $configuration[self::PROPERTY_TIME_TYPE_DEPRECATED];
         }
 
         return $time_rule;
@@ -48,6 +53,11 @@ class TimeRule extends ConfigurationSelectorRule
 
     public function apply($transformer, $header, $node)
     {
+        $time_type = $this->getProperty(self::PROPERTY_DATETIME_TYPE, $node);
+        if ($time_type) {
+            $this->type = $time_type;
+        }
+
         // Builds the image
         $time_string = $this->getProperty(self::PROPERTY_TIME, $node);
         if ($time_string) {
@@ -64,6 +74,8 @@ class TimeRule extends ConfigurationSelectorRule
                 )
             );
         }
+
+
 
         return $header;
     }


### PR DESCRIPTION
This fixes the design issue reported, of setting the type of the Time (UPDATE/PUBLISH) in a property outside the 'properties' field on the configuration.
- [x] Creates a new Getter: ConstantGetter, named by 'constant'
- [x] Updates the Parser configuration to use the new property
- [x] Adds/Changes the testcases to comprove this fix.

Fixes #172
