### PR TITLE
Issue 77 - Missing Footer title attribute

### DIFF
--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -146,14 +146,7 @@
             },
             {
                 "class": "FooterRelatedArticlesRule",
-                "selector" : "ul.op-related-articles",
-                "properties" : {
-                    "related.title" : {
-                        "type" : "string",
-                        "selector" : "ul.op-related-articles",
-                        "attribute": "title"
-                    }
-                }
+                "selector" : "ul.op-related-articles"
             },
             {
                 "class": "RelatedItemRule",

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterRelatedArticlesRule.php
@@ -13,8 +13,6 @@ use Facebook\InstantArticles\Elements\Footer;
 
 class FooterRelatedArticlesRule extends ConfigurationSelectorRule
 {
-    const PROPERTY_TITLE = 'related.title';
-
     public function getContextClass()
     {
         return Footer::getClassName();
@@ -30,24 +28,13 @@ class FooterRelatedArticlesRule extends ConfigurationSelectorRule
         $related_articles_rule = self::create();
         $related_articles_rule->withSelector($configuration['selector']);
 
-        $related_articles_rule->withProperty(
-            self::PROPERTY_TITLE,
-            self::retrieveProperty($configuration, self::PROPERTY_TITLE)
-        );
-
         return $related_articles_rule;
     }
 
     public function apply($transformer, $footer, $node)
     {
         $related_articles = RelatedArticles::create();
-
-        // Builds the image
-        $title = $this->getProperty(self::PROPERTY_TITLE, $node);
-        if ($title) {
-            $related_articles->withTitle($title);
-            $footer->withRelatedArticles($related_articles);
-        }
+        $footer->withRelatedArticles($related_articles);
 
         $transformer->transform($related_articles, $node);
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/RelatedArticlesRule.php
@@ -42,12 +42,11 @@ class RelatedArticlesRule extends ConfigurationSelectorRule
     {
         $related_articles = RelatedArticles::create();
 
-        // Builds the image
         $title = $this->getProperty(self::PROPERTY_TITLE, $node);
         if ($title) {
             $related_articles->withTitle($title);
-            $instant_article->addChild($related_articles);
         }
+        $instant_article->addChild($related_articles);
 
         $transformer->transform($related_articles, $node);
 

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -454,7 +454,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                     '<link rel="canonical" href="http://wp.localtest.me/2016/04/12/stress-on-earth/"/>'.
                     '<meta charset="utf-8"/>'.
                     '<meta property="op:generator" content="facebook-instant-articles-sdk-php"/>'.
-                    '<meta property="op:generator:version" content="1.5.2"/>'.
+                    '<meta property="op:generator:version" content="'.InstantArticle::CURRENT_VERSION.'"/>'.
                     '<meta property="op:markup_version" content="v1.0"/>'.
                 '</head>'.
                 '<body>'.

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example.html
@@ -182,7 +182,7 @@
           <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
           <p>Paragraph text as credits</p>
         </aside>
-        <ul class="op-related-articles" title="The related ones in the footer">
+        <ul class="op-related-articles">
           <li>
             <a href="http://example.com/article.html"></a>
           </li>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -48,6 +48,19 @@
         <img src="http://domain.com/image-header.png?suffix=yes"/>
         <figcaption>Some amazing moment captured by Photographer</figcaption>
       </figure>
+      <footer>
+        <ul class="op-related-articles">
+          <li>
+            <a href="http://example.com/article.html"></a>
+          </li>
+          <li data-sponsored="true">
+            <a href="http://example.com/sponsored-article.html"></a>
+          </li>
+          <li>
+            <a href="http://example.com/another-article.html"></a>
+          </li>
+        </ul>
+      </footer>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -176,14 +176,7 @@
   },
   {
     "class" : "FooterRelatedArticlesRule",
-    "selector" : "ul.op-related-articles",
-    "properties" : {
-      "related.title" : {
-        "type" : "string",
-        "selector" : "ul.op-related-articles",
-        "attribute" : "title"
-      }
-    }
+    "selector" : "ul.op-related-articles"
   },
   {
     "class" : "RelatedItemRule",

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -157,6 +157,49 @@
                         "selector" : "*"
                     }
                 }
-            }
+            },
+
+            {
+    "class" : "FooterRule",
+    "selector" : "footer"
+  },
+  {
+    "class" : "RelatedArticlesRule",
+    "selector" : "ul.op-related-articles",
+    "properties" : {
+      "related.title" : {
+        "type" : "exists",
+        "selector" : "ul.op-related-articles",
+        "attribute" : "title"
+      }
+    }
+  },
+  {
+    "class" : "FooterRelatedArticlesRule",
+    "selector" : "ul.op-related-articles",
+    "properties" : {
+      "related.title" : {
+        "type" : "string",
+        "selector" : "ul.op-related-articles",
+        "attribute" : "title"
+      }
+    }
+  },
+  {
+    "class" : "RelatedItemRule",
+    "selector" : "li",
+    "properties" : {
+      "related.sponsored" : {
+        "type" : "exists",
+        "selector" : "li",
+        "attribute": "data-sponsored"
+      },
+      "related.url" : {
+        "type" : "string",
+        "selector" : "a",
+        "attribute" : "href"
+      }
+    }
+  }
         ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple.html
@@ -37,5 +37,18 @@
             <img src="//domain.com/image-header.png" />
             <div class="image-caption">Some amazing moment captured by Photographer</div>
         </div>
+        <footer>
+            <ul class="op-related-articles">
+                <li>
+                    <a href="http://example.com/article.html"></a>
+                </li>
+                <li data-sponsored="true">
+                    <a href="http://example.com/sponsored-article.html"></a>
+                </li>
+                <li>
+                    <a href="http://example.com/another-article.html"></a>
+                </li>
+            </ul>
+        </footer>
     </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
@@ -187,7 +187,7 @@
           <p><a href="http://facebook.com/author" rel="facebook">著者</a>へのクレジット情報</p>
           <p>クレジットとしてのパラグラフ</p>
         </aside>
-        <ul class="op-related-articles" title="The related ones in the footer">
+        <ul class="op-related-articles">
           <li>
             <a href="http://example.com/article.html"></a>
           </li>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
@@ -13,29 +13,29 @@
       <header>
         <figure>
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
-          <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
+          <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
         </figure>
-        <h1>¥Ó¥Ã¥°¥È¥Ã¥× <b>¥¿¥¤¥È¥ë</b></h1>
-        <h2>¥¹¥â¡¼¥ë <b>¥µ¥Ö¥¿¥¤¥È¥ë</b></h2>
+        <h1>ï¿½Ó¥Ã¥ï¿½ï¿½È¥Ã¥ï¿½ <b>ï¿½ï¿½ï¿½ï¿½ï¿½È¥ï¿½</b></h1>
+        <h2>ï¿½ï¿½ï¿½â¡¼ï¿½ï¿½ <b>ï¿½ï¿½ï¿½Ö¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</b></h2>
         <time class="op-published" datetime="1984-08-14T19:30:00+00:00">August 14th, 7:30pm</time>
         <time class="op-modified" datetime="2016-02-10T10:00:00+00:00">February 10th, 10:00am</time>
-        <address><a href="#" title="Title of author">Ãø¼ÔÌ¾</a>
-          Ãø¼Ô¤Ë´Ø¤¹¤ë¾Ü¤·¤¤¾ðÊó
-          ¤µ¤é¤Ê¤ë¾ÜºÙ
+        <address><a href="#" title="Title of author">ï¿½ï¿½ï¿½ï¿½Ì¾</a>
+          ï¿½ï¿½ï¿½Ô¤Ë´Ø¤ï¿½ï¿½ï¿½ï¿½Ü¤ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+          ï¿½ï¿½ï¿½ï¿½ï¿½Ê¤ï¿½ï¿½Üºï¿½
         </address>
-        <address><a href="http://facebook.com/author" rel="facebook">FB¾å¤ÎÃø¼Ô</a>
-          facebookÆâ¤ÎÃø¼Ô¾ðÊó
+        <address><a href="http://facebook.com/author" rel="facebook">FBï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½</a>
+          facebookï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ô¾ï¿½ï¿½ï¿½
         </address>
-        <address><a title="PHP Programmer">³«È¯¼Ô</a>
+        <address><a title="PHP Programmer">ï¿½ï¿½È¯ï¿½ï¿½</a>
         </address>
-        <h3 class="op-kicker">µ­»ö¤Î¥­¥Ã¥«¡¼</h3>
+        <h3 class="op-kicker">ï¿½ï¿½ï¿½ï¿½ï¿½Î¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½</h3>
         <ul class="op-sponsors">
           <li>
             <a href="http://facebook.com/my-sponsor" rel="facebook"></a>
           </li>
         </ul>
       </header>
-      <p>¥Ñ¥é¥°¥é¥ÕÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
+      <p>ï¿½Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
       <figure data-feedback="fb:likes">
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
@@ -52,7 +52,7 @@
               "coordinates": [23.166667, 89.216667]
             },
             "properties": {
-              "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
+              "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
               "radius": 750000,
               "pivot": true,
               "style": "satellite",
@@ -65,9 +65,9 @@
       </figure>
       <figure data-feedback="fb:likes,fb:comments">
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
-        <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
+        <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
       </figure>
-      <p>Âè2ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
+      <p>ï¿½ï¿½2ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
       <figure class="op-slideshow">
         <figure>
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
@@ -78,30 +78,30 @@
         <figure>
           <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
         </figure>
-        <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
+        <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
       <ol>
-        <li>ºÇ½é¤Î¥ê¥¹¥È¹àÌÜ</li>
-        <li>¥Ñ¥é¥°¥é¥Õ</li>
-        <li>span¥¿¥°</li>
-        <li>divÆâ¤Î¥Æ¥­¥¹¥È¡©</li>
-        <li>li¾å¤Î¤½¤ÎÂ¾¤Î <a href="#">ÃÊÍî</a></li>
-        <li>ºÇ¸å¤Î¥ê¥¹¥È¹àÌÜ</li>
+        <li>ï¿½Ç½ï¿½ï¿½Î¥ê¥¹ï¿½È¹ï¿½ï¿½ï¿½</li>
+        <li>ï¿½Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½</li>
+        <li>spanï¿½ï¿½ï¿½ï¿½</li>
+        <li>divï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¡ï¿½</li>
+        <li>liï¿½ï¿½ï¿½Î¤ï¿½ï¿½ï¿½Â¾ï¿½ï¿½ <a href="#">ï¿½ï¿½ï¿½ï¿½</a></li>
+        <li>ï¿½Ç¸ï¿½ï¿½Î¥ê¥¹ï¿½È¹ï¿½ï¿½ï¿½</li>
       </ol>
-      <p>ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
+      <p>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
       <figure class="op-interactive">
         <iframe src="http://example.com/custom-interactive" class="column-width" height="60">
-          <h1>¥«¥¹¥¿¥à¥³¡¼¥É</h1>
-          <script>alert("¥Æ¥¹¥È");</script></iframe>
-        <figcaption>¤³¤Î¥°¥é¥Õ¥£¥Ã¥¯¤ÏÁÇÀ²¤é¤·¤¤¡£</figcaption>
+          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
+          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
+        <figcaption>ï¿½ï¿½ï¿½Î¥ï¿½ï¿½ï¿½ï¿½Õ¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½é¤·ï¿½ï¿½ï¿½ï¿½</figcaption>
       </figure>
       <figure class="op-ad">
         <iframe src="http://foo.com"></iframe>
       </figure>
-      <blockquote>blockquote¤Ïµ­»ö¤ÎÃæ¤Ç<b>magic</b>¤òºî¤ê¤Þ¤¹¡£</blockquote>
+      <blockquote>blockquoteï¿½Ïµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½<b>magic</b>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Þ¤ï¿½ï¿½ï¿½</blockquote>
       <figure class="op-map">
         <script type="application/json" class="op-geotag">
           {
@@ -113,48 +113,48 @@
               },
             "properties":
               {
-                "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
+                "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
                 "radius": 750000,
                 "pivot": true,
                 "style": "satellite",
               }
            }
         </script>
-        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">¥­¥ã¥×¥·¥ç¥óÍÑ¥¿¥¤¥È¥ë</h1><h2 class="op-vertical-below op-right">¥­¥ã¥×¥·¥ç¥óÍÑ¥µ¥Ö¥¿¥¤¥È¥ë</h2>
+        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h1><h2 class="op-vertical-below op-right">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½Ö¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h2>
 
 
-        <cite class="op-vertical-center op-left">¥­¥ã¥×¥·¥ç¥óÆâ¤Î¥¯¥ì¥¸¥Ã¥È</cite></figcaption>
+        <cite class="op-vertical-center op-left">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥ï¿½ï¿½ì¥¸ï¿½Ã¥ï¿½</cite></figcaption>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
       <aside>
-        »ä¤¿¤Á¤Ï¤É¤³¤ÇÀ®Ä¹¤µ¤»¤ë¤«¡¢²¿¤òÀ®Ä¹¤µ¤»¤ë¤«¡¢¤É¤¦¤ä¤Ã¤ÆÀ®Ä¹¤µ¤»¤ë¤«¡¢¤Ë¤Ä¤¤¤Æ¡¢¤â¤Ã¤È¸úÎ¨Åª¤Ë¤Ê¤ì¤ë¤Ï¤º¤Ç¤¹¡£
-        <cite>¥Õ¥ë¡¼¥Ä¥¹¥È¥«¥ó¥Ñ¥Ë¡¼</cite></aside>
-      <p>Âè2ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
+        ï¿½ä¤¿ï¿½ï¿½ï¿½Ï¤É¤ï¿½ï¿½ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½É¤ï¿½ï¿½ï¿½ï¿½Ã¤ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½Ë¤Ä¤ï¿½ï¿½Æ¡ï¿½ï¿½ï¿½ï¿½Ã¤È¸ï¿½Î¨Åªï¿½Ë¤Ê¤ï¿½ï¿½ï¿½ï¿½Ï¤ï¿½ï¿½Ç¤ï¿½ï¿½ï¿½
+        <cite>ï¿½Õ¥ë¡¼ï¿½Ä¥ï¿½ï¿½È¥ï¿½ï¿½ï¿½ï¿½Ñ¥Ë¡ï¿½</cite></aside>
+      <p>ï¿½ï¿½2ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
       <figure class="op-tracker">
         <iframe>
-          <h1>¥«¥¹¥¿¥à¥³¡¼¥É</h1>
-          <script>alert("¥Æ¥¹¥È");</script></iframe>
+          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
+          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
       </figure>
       <figure class="op-tracker">
         <iframe>
-          <h1>¥È¥é¥Ã¥«¡¼ÍÑ¥¹¥¯¥ê¥×¥È</h1>
-          <div><script>alert("¥Æ¥¹¥È");</script></div>
+          <h1>ï¿½È¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½</h1>
+          <div><script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></div>
         </iframe>
       </figure>
       <figure class="op-interactive">
         <iframe class="no-margin">
-          <h1>¥½¡¼¥·¥ã¥ëËä¤á¹þ¤ßÍÑ¥«¥¹¥¿¥à¥³¡¼¥É</h1>
-          <script>alert("¥Æ¥¹¥È");</script></iframe>
+          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
+          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
       </figure>
       <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>
-        <figcaption class="op-vertical-below"><h1>¥Ó¥Ç¥ª¥¿¥¤¥È¥ë</h1>
+        <figcaption class="op-vertical-below"><h1>ï¿½Ó¥Ç¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h1>
 
-          <cite>Â°À­¥½¡¼¥¹</cite></figcaption>
+          <cite>Â°ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
         <script type="application/json" class="op-geotag">
           {
             "type": "Feature",
@@ -163,7 +163,7 @@
               "coordinates": [ [23.166667, 89.216667], [23.166667, 89.216667] ]
             },
             "properties": {
-              "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
+              "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
               "radius": 750000,
               "pivot": true,
               "style": "satellite",
@@ -184,10 +184,10 @@
       </ul>
       <footer>
         <aside>
-          <p><a href="http://facebook.com/author" rel="facebook">Ãø¼Ô</a>¤Ø¤Î¥¯¥ì¥¸¥Ã¥È¾ðÊó</p>
-          <p>¥¯¥ì¥¸¥Ã¥È¤È¤·¤Æ¤Î¥Ñ¥é¥°¥é¥Õ</p>
+          <p><a href="http://facebook.com/author" rel="facebook">ï¿½ï¿½ï¿½ï¿½</a>ï¿½Ø¤Î¥ï¿½ï¿½ì¥¸ï¿½Ã¥È¾ï¿½ï¿½ï¿½</p>
+          <p>ï¿½ï¿½ï¿½ì¥¸ï¿½Ã¥È¤È¤ï¿½ï¿½Æ¤Î¥Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½</p>
         </aside>
-        <ul class="op-related-articles" title="The related ones in the footer">
+        <ul class="op-related-articles">
           <li>
             <a href="http://example.com/article.html"></a>
           </li>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
@@ -13,29 +13,29 @@
       <header>
         <figure>
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
-          <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
+          <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
         </figure>
-        <h1>ï¿½Ó¥Ã¥ï¿½ï¿½È¥Ã¥ï¿½ <b>ï¿½ï¿½ï¿½ï¿½ï¿½È¥ï¿½</b></h1>
-        <h2>ï¿½ï¿½ï¿½â¡¼ï¿½ï¿½ <b>ï¿½ï¿½ï¿½Ö¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</b></h2>
+        <h1>¥Ó¥Ã¥°¥È¥Ã¥× <b>¥¿¥¤¥È¥ë</b></h1>
+        <h2>¥¹¥â¡¼¥ë <b>¥µ¥Ö¥¿¥¤¥È¥ë</b></h2>
         <time class="op-published" datetime="1984-08-14T19:30:00+00:00">August 14th, 7:30pm</time>
         <time class="op-modified" datetime="2016-02-10T10:00:00+00:00">February 10th, 10:00am</time>
-        <address><a href="#" title="Title of author">ï¿½ï¿½ï¿½ï¿½Ì¾</a>
-          ï¿½ï¿½ï¿½Ô¤Ë´Ø¤ï¿½ï¿½ï¿½ï¿½Ü¤ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-          ï¿½ï¿½ï¿½ï¿½ï¿½Ê¤ï¿½ï¿½Üºï¿½
+        <address><a href="#" title="Title of author">Ãø¼ÔÌ¾</a>
+          Ãø¼Ô¤Ë´Ø¤¹¤ë¾Ü¤·¤¤¾ðÊó
+          ¤µ¤é¤Ê¤ë¾ÜºÙ
         </address>
-        <address><a href="http://facebook.com/author" rel="facebook">FBï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½</a>
-          facebookï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ô¾ï¿½ï¿½ï¿½
+        <address><a href="http://facebook.com/author" rel="facebook">FB¾å¤ÎÃø¼Ô</a>
+          facebookÆâ¤ÎÃø¼Ô¾ðÊó
         </address>
-        <address><a title="PHP Programmer">ï¿½ï¿½È¯ï¿½ï¿½</a>
+        <address><a title="PHP Programmer">³«È¯¼Ô</a>
         </address>
-        <h3 class="op-kicker">ï¿½ï¿½ï¿½ï¿½ï¿½Î¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½</h3>
+        <h3 class="op-kicker">µ­»ö¤Î¥­¥Ã¥«¡¼</h3>
         <ul class="op-sponsors">
           <li>
             <a href="http://facebook.com/my-sponsor" rel="facebook"></a>
           </li>
         </ul>
       </header>
-      <p>ï¿½Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
+      <p>¥Ñ¥é¥°¥é¥ÕÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
       <figure data-feedback="fb:likes">
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
@@ -52,7 +52,7 @@
               "coordinates": [23.166667, 89.216667]
             },
             "properties": {
-              "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
+              "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
               "radius": 750000,
               "pivot": true,
               "style": "satellite",
@@ -65,9 +65,9 @@
       </figure>
       <figure data-feedback="fb:likes,fb:comments">
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
-        <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
+        <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
       </figure>
-      <p>ï¿½ï¿½2ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
+      <p>Âè2ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
       <figure class="op-slideshow">
         <figure>
           <img src="https://jpeg.org/images/jpegls-home.jpg"/>
@@ -78,30 +78,30 @@
         <figure>
           <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
         </figure>
-        <figcaption><h1>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½Ì¾</h1>ï¿½Æ¥ï¿½ï¿½ï¿½ï¿½È¥Î¡ï¿½ï¿½ï¿½<cite>ï¿½ï¿½ï¿½á¡¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
+        <figcaption><h1>¥¤¥á¡¼¥¸Ì¾</h1>¥Æ¥­¥¹¥È¥Î¡¼¥É<cite>¥¤¥á¡¼¥¸¥­¥ã¥×¥·¥ç¥ó</cite></figcaption>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
       <ol>
-        <li>ï¿½Ç½ï¿½ï¿½Î¥ê¥¹ï¿½È¹ï¿½ï¿½ï¿½</li>
-        <li>ï¿½Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½</li>
-        <li>spanï¿½ï¿½ï¿½ï¿½</li>
-        <li>divï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¡ï¿½</li>
-        <li>liï¿½ï¿½ï¿½Î¤ï¿½ï¿½ï¿½Â¾ï¿½ï¿½ <a href="#">ï¿½ï¿½ï¿½ï¿½</a></li>
-        <li>ï¿½Ç¸ï¿½ï¿½Î¥ê¥¹ï¿½È¹ï¿½ï¿½ï¿½</li>
+        <li>ºÇ½é¤Î¥ê¥¹¥È¹àÌÜ</li>
+        <li>¥Ñ¥é¥°¥é¥Õ</li>
+        <li>span¥¿¥°</li>
+        <li>divÆâ¤Î¥Æ¥­¥¹¥È¡©</li>
+        <li>li¾å¤Î¤½¤ÎÂ¾¤Î <a href="#">ÃÊÍî</a></li>
+        <li>ºÇ¸å¤Î¥ê¥¹¥È¹àÌÜ</li>
       </ol>
-      <p>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
+      <p>ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
       <figure class="op-interactive">
         <iframe src="http://example.com/custom-interactive" class="column-width" height="60">
-          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
-          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
-        <figcaption>ï¿½ï¿½ï¿½Î¥ï¿½ï¿½ï¿½ï¿½Õ¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½é¤·ï¿½ï¿½ï¿½ï¿½</figcaption>
+          <h1>¥«¥¹¥¿¥à¥³¡¼¥É</h1>
+          <script>alert("¥Æ¥¹¥È");</script></iframe>
+        <figcaption>¤³¤Î¥°¥é¥Õ¥£¥Ã¥¯¤ÏÁÇÀ²¤é¤·¤¤¡£</figcaption>
       </figure>
       <figure class="op-ad">
         <iframe src="http://foo.com"></iframe>
       </figure>
-      <blockquote>blockquoteï¿½Ïµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½<b>magic</b>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Þ¤ï¿½ï¿½ï¿½</blockquote>
+      <blockquote>blockquote¤Ïµ­»ö¤ÎÃæ¤Ç<b>magic</b>¤òºî¤ê¤Þ¤¹¡£</blockquote>
       <figure class="op-map">
         <script type="application/json" class="op-geotag">
           {
@@ -113,48 +113,48 @@
               },
             "properties":
               {
-                "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
+                "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
                 "radius": 750000,
                 "pivot": true,
                 "style": "satellite",
               }
            }
         </script>
-        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h1><h2 class="op-vertical-below op-right">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½Ö¥ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h2>
+        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">¥­¥ã¥×¥·¥ç¥óÍÑ¥¿¥¤¥È¥ë</h1><h2 class="op-vertical-below op-right">¥­¥ã¥×¥·¥ç¥óÍÑ¥µ¥Ö¥¿¥¤¥È¥ë</h2>
 
 
-        <cite class="op-vertical-center op-left">ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥ï¿½ï¿½ì¥¸ï¿½Ã¥ï¿½</cite></figcaption>
+        <cite class="op-vertical-center op-left">¥­¥ã¥×¥·¥ç¥óÆâ¤Î¥¯¥ì¥¸¥Ã¥È</cite></figcaption>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
       <aside>
-        ï¿½ä¤¿ï¿½ï¿½ï¿½Ï¤É¤ï¿½ï¿½ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½É¤ï¿½ï¿½ï¿½ï¿½Ã¤ï¿½ï¿½ï¿½Ä¹ï¿½ï¿½ï¿½ï¿½ï¿½ë¤«ï¿½ï¿½ï¿½Ë¤Ä¤ï¿½ï¿½Æ¡ï¿½ï¿½ï¿½ï¿½Ã¤È¸ï¿½Î¨Åªï¿½Ë¤Ê¤ï¿½ï¿½ï¿½ï¿½Ï¤ï¿½ï¿½Ç¤ï¿½ï¿½ï¿½
-        <cite>ï¿½Õ¥ë¡¼ï¿½Ä¥ï¿½ï¿½È¥ï¿½ï¿½ï¿½ï¿½Ñ¥Ë¡ï¿½</cite></aside>
-      <p>ï¿½ï¿½2ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î¥Æ¥ï¿½ï¿½ï¿½ï¿½È¤Î¥Æ¥ï¿½ï¿½È¤Ç¤ï¿½ï¿½ï¿½</p>
+        »ä¤¿¤Á¤Ï¤É¤³¤ÇÀ®Ä¹¤µ¤»¤ë¤«¡¢²¿¤òÀ®Ä¹¤µ¤»¤ë¤«¡¢¤É¤¦¤ä¤Ã¤ÆÀ®Ä¹¤µ¤»¤ë¤«¡¢¤Ë¤Ä¤¤¤Æ¡¢¤â¤Ã¤È¸úÎ¨Åª¤Ë¤Ê¤ì¤ë¤Ï¤º¤Ç¤¹¡£
+        <cite>¥Õ¥ë¡¼¥Ä¥¹¥È¥«¥ó¥Ñ¥Ë¡¼</cite></aside>
+      <p>Âè2ÃÊÍîÆâ¤Î¥Æ¥­¥¹¥È¤Î¥Æ¥¹¥È¤Ç¤¹¡£</p>
       <figure class="op-tracker">
         <iframe>
-          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
-          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
+          <h1>¥«¥¹¥¿¥à¥³¡¼¥É</h1>
+          <script>alert("¥Æ¥¹¥È");</script></iframe>
       </figure>
       <figure class="op-tracker">
         <iframe>
-          <h1>ï¿½È¥ï¿½ï¿½Ã¥ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½×¥ï¿½</h1>
-          <div><script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></div>
+          <h1>¥È¥é¥Ã¥«¡¼ÍÑ¥¹¥¯¥ê¥×¥È</h1>
+          <div><script>alert("¥Æ¥¹¥È");</script></div>
         </iframe>
       </figure>
       <figure class="op-interactive">
         <iframe class="no-margin">
-          <h1>ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½à¥³ï¿½ï¿½ï¿½ï¿½</h1>
-          <script>alert("ï¿½Æ¥ï¿½ï¿½ï¿½");</script></iframe>
+          <h1>¥½¡¼¥·¥ã¥ëËä¤á¹þ¤ßÍÑ¥«¥¹¥¿¥à¥³¡¼¥É</h1>
+          <script>alert("¥Æ¥¹¥È");</script></iframe>
       </figure>
       <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>
-        <figcaption class="op-vertical-below"><h1>ï¿½Ó¥Ç¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½È¥ï¿½</h1>
+        <figcaption class="op-vertical-below"><h1>¥Ó¥Ç¥ª¥¿¥¤¥È¥ë</h1>
 
-          <cite>Â°ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½</cite></figcaption>
+          <cite>Â°À­¥½¡¼¥¹</cite></figcaption>
         <script type="application/json" class="op-geotag">
           {
             "type": "Feature",
@@ -163,7 +163,7 @@
               "coordinates": [ [23.166667, 89.216667], [23.166667, 89.216667] ]
             },
             "properties": {
-              "title": "ï¿½Ð¥ó¥°¥ï¿½ï¿½Ç¥ï¿½ï¿½å¡¡ï¿½ï¿½ï¿½ç¥½ï¿½ï¿½ï¿½ë¸©",
+              "title": "¥Ð¥ó¥°¥é¥Ç¥·¥å¡¡¥¸¥ç¥½¡¼¥ë¸©",
               "radius": 750000,
               "pivot": true,
               "style": "satellite",
@@ -184,8 +184,8 @@
       </ul>
       <footer>
         <aside>
-          <p><a href="http://facebook.com/author" rel="facebook">ï¿½ï¿½ï¿½ï¿½</a>ï¿½Ø¤Î¥ï¿½ï¿½ì¥¸ï¿½Ã¥È¾ï¿½ï¿½ï¿½</p>
-          <p>ï¿½ï¿½ï¿½ì¥¸ï¿½Ã¥È¤È¤ï¿½ï¿½Æ¤Î¥Ñ¥é¥°ï¿½ï¿½ï¿½ï¿½</p>
+          <p><a href="http://facebook.com/author" rel="facebook">Ãø¼Ô</a>¤Ø¤Î¥¯¥ì¥¸¥Ã¥È¾ðÊó</p>
+          <p>¥¯¥ì¥¸¥Ã¥È¤È¤·¤Æ¤Î¥Ñ¥é¥°¥é¥Õ</p>
         </aside>
         <ul class="op-related-articles">
           <li>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
@@ -187,7 +187,7 @@
           <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
           <p>Paragraph text as credits</p>
         </aside>
-        <ul class="op-related-articles" title="The related ones in the footer">
+        <ul class="op-related-articles">
           <li>
             <a href="http://example.com/article.html"></a>
           </li>


### PR DESCRIPTION
This PR

* [x] Fixes the issue of removing the RelatedArticles footer section if no title provided for the transformation
* [x] Fixes the tests and adds another test cases

Fixes #77
Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/550
