### PR TITLE
Added default switch to turn on/off the comments and likes

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -96,8 +96,8 @@ class Image extends Audible implements Container
      */
     private function __construct()
     {
-       $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
-       $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
+        $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
+        $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
     }
 
     /**

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -404,7 +404,8 @@ class Image extends Audible implements Container
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable likes on images per default or false to disable like on images.
      */
-    public static function setDefaultLikeEnabled($enabled) {
+    public static function setDefaultLikeEnabled($enabled)
+    {
         self::$defaultLikeEnabled = $enabled;
     }
 
@@ -415,7 +416,8 @@ class Image extends Audible implements Container
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable comments on images per default or false to disable commenting on images.
      */
-    public static function setDefaultCommentEnabled($enabled) {
+    public static function setDefaultCommentEnabled($enabled)
+    {
         self::$defaultCommentEnabled = $enabled;
     }
 

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -420,5 +420,4 @@ class Image extends Audible implements Container
     {
         self::$defaultCommentEnabled = $enabled;
     }
-
 }

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -41,6 +41,16 @@ class Image extends Audible implements Container
     const NON_INTERACTIVE = 'non-interactive';
 
     /**
+     * @var boolean marks if any created image will have likes enabled by default
+     */
+    public static $DEFAULT_LIKE_ENABLED = false;
+
+    /**
+     * @var boolean marks if any created image will have comments enabled by default
+     */
+    public static $DEFAULT_COMMENT_ENABLED = false;
+
+    /**
      * @var Caption The caption for Image
      */
     private $caption;
@@ -86,6 +96,8 @@ class Image extends Audible implements Container
      */
     private function __construct()
     {
+       $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
+       $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
     }
 
     /**

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -43,12 +43,12 @@ class Image extends Audible implements Container
     /**
      * @var boolean marks if any created image will have likes enabled by default
      */
-    public static $DEFAULT_LIKE_ENABLED = false;
+    public static $defaultLikeEnabled = false;
 
     /**
      * @var boolean marks if any created image will have comments enabled by default
      */
-    public static $DEFAULT_COMMENT_ENABLED = false;
+    public static $defaultCommentEnabled = false;
 
     /**
      * @var Caption The caption for Image
@@ -96,8 +96,8 @@ class Image extends Audible implements Container
      */
     private function __construct()
     {
-        $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
-        $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
+        $this->isLikeEnabled = self::$defaultLikeEnabled;
+        $this->isCommentsEnabled = self::$defaultCommentEnabled;
     }
 
     /**
@@ -396,4 +396,27 @@ class Image extends Audible implements Container
 
         return $children;
     }
+
+    /**
+     * Modify the default setup to enable/disable likes in images
+     *
+     * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
+     * this might not work as expected. (you will need to set this in all working threads manually)
+     * @param boolean $enabled inform true to enable likes on images per default or false to disable like on images.
+     */
+    public static function setDefaultLikeEnabled($enabled) {
+        self::$defaultLikeEnabled = $enabled;
+    }
+
+    /**
+     * Modify the default setup to enable/disable comments in images
+     *
+     * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
+     * this might not work as expected. (you will need to set this in all working threads manually)
+     * @param boolean $enabled inform true to enable comments on images per default or false to disable commenting on images.
+     */
+    public static function setDefaultCommentEnabled($enabled) {
+        self::$defaultCommentEnabled = $enabled;
+    }
+
 }

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -124,8 +124,8 @@ class Video extends Element implements Container
 
     private function __construct()
     {
-      $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
-      $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
+        $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
+        $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
     }
 
     /**

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -45,6 +45,16 @@ class Video extends Element implements Container
     const DATA_FADE = 'data-fade';
 
     /**
+     * @var boolean marks if any created image will have likes enabled by default
+     */
+    public static $DEFAULT_LIKE_ENABLED = false;
+
+    /**
+     * @var boolean marks if any created image will have comments enabled by default
+     */
+    public static $DEFAULT_COMMENT_ENABLED = false;
+
+    /**
      * @var Caption The caption for Video
      */
     private $caption;
@@ -114,6 +124,8 @@ class Video extends Element implements Container
 
     private function __construct()
     {
+      $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
+      $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
     }
 
     /**

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -47,12 +47,12 @@ class Video extends Element implements Container
     /**
      * @var boolean marks if any created image will have likes enabled by default
      */
-    public static $DEFAULT_LIKE_ENABLED = false;
+    private static $defaultLikeEnabled = false;
 
     /**
      * @var boolean marks if any created image will have comments enabled by default
      */
-    public static $DEFAULT_COMMENT_ENABLED = false;
+    private static $defaultCommentEnabled = false;
 
     /**
      * @var Caption The caption for Video
@@ -124,8 +124,8 @@ class Video extends Element implements Container
 
     private function __construct()
     {
-        $this->isLikeEnabled = self::$DEFAULT_LIKE_ENABLED;
-        $this->isCommentsEnabled = self::$DEFAULT_COMMENT_ENABLED;
+        $this->isLikeEnabled = self::$defaultLikeEnabled;
+        $this->isCommentsEnabled = self::$defaultCommentEnabled;
     }
 
     /**
@@ -444,6 +444,29 @@ class Video extends Element implements Container
     {
         return $this->geoTag;
     }
+
+    /**
+     * Modify the default setup to enable/disable likes in videos
+     *
+     * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
+     * this might not work as expected. (you will need to set this in all working threads manually)
+     * @param boolean $enabled inform true to enable likes on videos per default or false to disable like on videos.
+     */
+    public static function setDefaultLikeEnabled($enabled) {
+        self::$defaultLikeEnabled = $enabled;
+    }
+
+    /**
+     * Modify the default setup to enable/disable comments in videos
+     *
+     * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
+     * this might not work as expected. (you will need to set this in all working threads manually)
+     * @param boolean $enabled inform true to enable comments on videos per default or false to disable commenting on videos.
+     */
+    public static function setDefaultCommentEnabled($enabled) {
+        self::$defaultCommentEnabled = $enabled;
+    }
+
 
     /**
      * Structure and create the full Video in a XML format DOMElement.

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -452,7 +452,8 @@ class Video extends Element implements Container
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable likes on videos per default or false to disable like on videos.
      */
-    public static function setDefaultLikeEnabled($enabled) {
+    public static function setDefaultLikeEnabled($enabled)
+    {
         self::$defaultLikeEnabled = $enabled;
     }
 
@@ -463,7 +464,8 @@ class Video extends Element implements Container
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable comments on videos per default or false to disable commenting on videos.
      */
-    public static function setDefaultCommentEnabled($enabled) {
+    public static function setDefaultCommentEnabled($enabled)
+    {
         self::$defaultCommentEnabled = $enabled;
     }
 


### PR DESCRIPTION
This PR

* [x] Creates a default setup for enabling comments and likes to videos and images

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/36
Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/340