### PR TITLE
Allow Footer#withCopyright to take Small element

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Footer.php
+++ b/src/Facebook/InstantArticles/Elements/Footer.php
@@ -104,7 +104,7 @@ class Footer extends Element implements Container
      */
     public function withCopyright($copyright)
     {
-        Type::enforce($copyright, Type::STRING);
+        Type::enforce($copyright, [Type::STRING, Small::getClassName()]);
         $this->copyright = $copyright;
 
         return $this;
@@ -188,9 +188,13 @@ class Footer extends Element implements Container
         }
 
         if ($this->copyright) {
-            $small = $document->createElement('small');
-            $small->appendChild($document->createTextNode($this->copyright));
-            $footer->appendChild($small);
+            if (Type::is($this->copyright, Type::STRING)) {
+                $small = $document->createElement('small');
+                $small->appendChild($document->createTextNode($this->copyright));
+                $footer->appendChild($small);
+            } else {
+                $footer->appendChild($this->copyright->toDOMElement($document));
+            }
         }
 
         if ($this->relatedArticles) {

--- a/src/Facebook/InstantArticles/Elements/Small.php
+++ b/src/Facebook/InstantArticles/Elements/Small.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Elements;
+
+/**
+ * A small Text container used in footer
+ *
+ * @see {link:https://developers.intern.facebook.com/docs/instant-articles/reference/footer}
+ */
+class Small extends TextContainer
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return Small
+     */
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * Structure and create <small> node.
+     *
+     * @param \DOMDocument $document - The document where this element will be appended (optional).
+     *
+     * @return \DOMElement
+     */
+    public function toDOMElement($document = null)
+    {
+        if (!$document) {
+            $document = new \DOMDocument();
+        }
+
+        if (!$this->isValid()) {
+            return $this->emptyElement($document);
+        }
+
+        $small = $document->createElement('small');
+
+        $small->appendChild($this->textToDOMDocumentFragment($document));
+
+        return $small;
+    }
+}

--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -130,6 +130,10 @@
                 "selector" : "header"
             },
             {
+                "class": "FooterSmallRule",
+                "selector": "small"
+            },
+            {
                 "class": "FooterRule",
                 "selector" : "footer"
             },

--- a/src/Facebook/InstantArticles/Transformer/Rules/FooterSmallRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/FooterSmallRule.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Rules;
+
+use Facebook\InstantArticles\Elements\Footer;
+use Facebook\InstantArticles\Elements\Small;
+
+class FooterSmallRule extends ConfigurationSelectorRule
+{
+    public function getContextClass()
+    {
+        return Footer::getClassName();
+    }
+
+    public static function create()
+    {
+        return new FooterSmallRule();
+    }
+
+    public static function createFrom($configuration)
+    {
+        return self::create()->withSelector($configuration['selector']);
+    }
+
+    public function apply($transformer, $footer, $element)
+    {
+        $small = Small::create();
+        $footer->withCopyright($small);
+        $transformer->transform($small, $element);
+        return $footer;
+    }
+}

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -106,6 +106,31 @@ class FooterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
+    public function testRenderWithCopyrightSmallElement()
+    {
+        $small =
+            Small::create()
+                ->appendText("2016 ")
+                ->appendText(
+                    Anchor::create()
+                        ->withHRef('https://facebook.com')
+                        ->appendText('Facebook')
+                );
+        $footer =
+            Footer::create()
+                ->withCopyright($small);
+
+        $expected =
+            '<footer>'.
+                '<small>'.
+                    '2016 <a href="https://facebook.com">Facebook</a>'.
+                '</small>'.
+            '</footer>';
+
+        $rendered = $footer->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
     public function testRenderWithRelatedArticles()
     {
         $footer =

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example.html
@@ -182,6 +182,9 @@
           <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
           <p>Paragraph text as credits</p>
         </aside>
+        <small>
+          Copyright <a href="http://example.com">with link</a> and <b>inline style</b>
+        </small>
         <ul class="op-related-articles">
           <li>
             <a href="http://example.com/article.html"></a>


### PR DESCRIPTION
This PR

- [x] introduce `Small` element
- [x] change `Footer#withCopyright` function to take Small element
- [x] define rule for `<small>` under `<footer>`

Fixes #196

