### PR TITLE
Adds parameter for formatting content ingested

### DIFF
--- a/src/Facebook/InstantArticles/Client/Client.php
+++ b/src/Facebook/InstantArticles/Client/Client.php
@@ -85,10 +85,11 @@ class Client
      *
      * @param InstantArticle $article The article to import
      * @param bool|false $published Specifies if this article should be taken live or not. Optional. Default: false.
+     * @param bool|false $formatOutput Specifies if this article should be formatted after transformation. Optional. Default: false.
      *
      * @return int The submission status ID. It is not the article ID. (Since 1.3.0)
      */
-    public function importArticle($article, $published = false, $forceRescrape = false)
+    public function importArticle($article, $published = false, $forceRescrape = false, $formatOutput = false)
     {
         Type::enforce($article, 'Facebook\InstantArticles\Elements\InstantArticleInterface');
         Type::enforce($published, Type::BOOLEAN);
@@ -98,7 +99,7 @@ class Client
 
         // Assume default access token is set on $this->facebook
         $response = $this->facebook->post($this->pageID . Client::EDGE_NAME, [
-          'html_source' => $article->render(),
+          'html_source' => $article->render(null, $formatOutput),
           'published' => $published,
           'development_mode' => $this->developmentMode,
         ]);

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -396,6 +396,7 @@ class InstantArticle extends Element implements Container, InstantArticleInterfa
 
     public function render($doctype = '<!doctype html>', $format = false)
     {
+        $doctype = is_null( $doctype ) ? '<!doctype html>' : $doctype;
         return parent::render($doctype, $format);
     }
 

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -396,7 +396,7 @@ class InstantArticle extends Element implements Container, InstantArticleInterfa
 
     public function render($doctype = '<!doctype html>', $format = false)
     {
-        $doctype = is_null( $doctype ) ? '<!doctype html>' : $doctype;
+        $doctype = is_null($doctype) ? '<!doctype html>' : $doctype;
         return parent::render($doctype, $format);
     }
 


### PR DESCRIPTION
[x] Adds a treatment for "NULL" informed parameter as content type
[x] Implements default value as false for formatted articles
[x] Respects and overwrites if value informed

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/625

It is a pré-requisite for: https://github.com/Automattic/facebook-instant-articles-wp/pull/635
