### PR TITLE
Added support to video parsing within an Slideshow

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Slideshow.php
+++ b/src/Facebook/InstantArticles/Elements/Slideshow.php
@@ -37,9 +37,9 @@ class Slideshow extends Audible implements Container
     private $caption;
 
     /**
-     * @var Image[] the images hosted on web that will be shown on the slideshow
+     * @var Mixed<Image|Video>[] the images or videos hosted on web that will be shown on the slideshow
      */
-    private $article_images = [];
+    private $slideshow_items = [];
 
     /**
      * @var string The json geotag content inside the script geotag
@@ -97,13 +97,13 @@ class Slideshow extends Audible implements Container
     public function withImages($article_images)
     {
         Type::enforceArrayOf($article_images, Image::getClassName());
-        $this->article_images = $article_images;
+        $this->slideshow_items = $article_images;
 
         return $this;
     }
 
     /**
-     * Adds a new image to the slideshow. It is REQUIRED.
+     * Adds a new image to the slideshow.
      *
      * @param Image $article_image The image.
      *
@@ -112,7 +112,37 @@ class Slideshow extends Audible implements Container
     public function addImage($article_image)
     {
         Type::enforce($article_image, Image::getClassName());
-        $this->article_images[] = $article_image;
+        $this->slideshow_items[] = $article_image;
+
+        return $this;
+    }
+
+    /**
+     * Sets the Video list of videos for the slideshow.
+     *
+     * @param Video[] The videos. Ie: http://domain.com/img.png
+     *
+     * @return $this
+     */
+    public function withVideos($article_videos)
+    {
+        Type::enforceArrayOf($article_videos, Video::getClassName());
+        $this->slideshow_items = $article_videos;
+
+        return $this;
+    }
+
+    /**
+     * Adds a new image to the slideshow. It is REQUIRED.
+     *
+     * @param Video $article_image The image.
+     *
+     * @return $this
+     */
+    public function addVideo($article_video)
+    {
+        Type::enforce($article_video, Video::getClassName());
+        $this->slideshow_items[] = $article_video;
 
         return $this;
     }
@@ -159,10 +189,19 @@ class Slideshow extends Audible implements Container
 
     /**
      * @return Image[] The ArticleImages content of the slideshow
+     * @deprecated use getSlideshowItems()
      */
     public function getArticleImages()
     {
-        return $this->article_images;
+        return $this->slideshow_items;
+    }
+
+    /**
+     * @return Mixed<Image|Video>[] The content items of the slideshow
+     */
+    public function getSlideshowItems()
+    {
+        return $this->slideshow_items;
     }
 
     /**
@@ -210,10 +249,10 @@ class Slideshow extends Audible implements Container
         $element->setAttribute('class', 'op-slideshow');
 
         // URL markup required
-        if ($this->article_images) {
-            foreach ($this->article_images as $article_image) {
-                $article_image_element = $article_image->toDOMElement($document);
-                $element->appendChild($article_image_element);
+        if ($this->slideshow_items) {
+            foreach ($this->slideshow_items as $slideshow_item) {
+                $slideshow_item_element = $slideshow_item->toDOMElement($document);
+                $element->appendChild($slideshow_item_element);
             }
         }
 
@@ -247,7 +286,7 @@ class Slideshow extends Audible implements Container
      */
     public function isValid()
     {
-        foreach ($this->article_images as $item) {
+        foreach ($this->slideshow_items as $item) {
             if ($item->isValid()) {
                 return true;
             }
@@ -265,9 +304,9 @@ class Slideshow extends Audible implements Container
     {
         $children = array();
 
-        if ($this->article_images) {
-            foreach ($this->article_images as $article_image) {
-                $children[] = $article_image;
+        if ($this->slideshow_items) {
+            foreach ($this->slideshow_items as $slideshow_item) {
+                $children[] = $slideshow_item;
             }
         }
 

--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -598,6 +598,59 @@
                 }
             },
             {
+                "class": "SlideshowVideoRule",
+                "selector" : "figure",
+                "containsChild": "video",
+                "properties" : {
+                    "video.url" : {
+                        "type" : "string",
+                        "selector" : "source",
+                        "attribute": "src"
+                    },
+                    "video.type" : {
+                        "type" : "string",
+                        "selector" : "source",
+                        "attribute": "type"
+                    },
+                    "aspect-fit": {
+                        "type": "exists",
+                        "selector" : "figure[data-mode=aspect-fit]"
+                    },
+                    "aspect-fit-only": {
+                        "type": "exists",
+                        "selector" : "figure[data-mode=aspect-fit-only]"
+                    },
+                    "fullscreen": {
+                        "type": "exists",
+                        "selector" : "figure[data-mode=fullscreen]"
+                    },
+                    "non-interactive": {
+                        "type": "exists",
+                        "selector" : "figure[data-mode=non-interactive]"
+                    },
+                    "video.controls": {
+                        "type": "exists",
+                        "selector" : "video",
+                        "attribute": "controls"
+                    },
+                    "video.playback": {
+                        "type": "exists",
+                        "selector" : "video",
+                        "attribute": "data-fb-disable-autoplay"
+                    },
+                    "video.like" : {
+                        "type" : "exists",
+                        "selector" : "figure[data-feedback*='fb:likes']",
+                        "attribute": "data-feedback"
+                    },
+                    "video.comments" : {
+                        "type" : "exists",
+                        "selector" : "figure[data-feedback*='fb:comments']",
+                        "attribute": "data-feedback"
+                    }
+                }
+            },
+            {
                 "class": "SlideshowRule",
                 "selector" : "figure.op-slideshow"
             },

--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowVideoRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowVideoRule.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Rules;
+
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+use Facebook\InstantArticles\Elements\Video;
+use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Elements\Slideshow;
+use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
+
+class SlideshowVideoRule extends ConfigurationSelectorRule
+{
+    const PROPERTY_VIDEO_URL = 'video.url';
+    const PROPERTY_VIDEO_TYPE = 'video.type';
+    const PROPERTY_PLAYBACK_MODE = 'video.playback';
+    const PROPERTY_CONTROLS = 'video.controls';
+    const PROPERTY_LIKE = 'video.like';
+    const PROPERTY_COMMENTS = 'video.comments';
+
+    /**
+     * @var string
+     */
+    private $childSelector;
+
+    public function getContextClass()
+    {
+        return Slideshow::getClassName();
+    }
+
+    public static function create()
+    {
+        return new SlideshowVideoRule();
+    }
+
+    public function withContainsChild($child_selector)
+    {
+        $this->childSelector = $child_selector;
+        return $this;
+    }
+
+    public function matchesNode($node)
+    {
+        $matches_node = parent::matchesNode($node);
+        if ($matches_node && $this->childSelector) {
+            $matches_node = false;
+            if ($node->hasChildNodes()) {
+                foreach ($node->childNodes as $child) {
+                    $domXPath = new \DOMXPath($child->ownerDocument);
+                    $converter = new CssSelectorConverter();
+                    $xpath = $converter->toXPath($this->childSelector);
+                    $results = $domXPath->query($xpath, $node);
+                    foreach ($results as $result) {
+                        if ($result === $child) {
+                            $matches_node = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $matches_node;
+    }
+
+    public static function createFrom($configuration)
+    {
+        $video_rule = self::create();
+        $video_rule->withSelector($configuration['selector']);
+
+        if (isset($configuration['containsChild'])) {
+            $video_rule->withContainsChild($configuration['containsChild']);
+        }
+
+        $video_rule->withProperties(
+            [
+                self::PROPERTY_VIDEO_URL,
+                self::PROPERTY_VIDEO_TYPE,
+
+                Video::ASPECT_FIT,
+                Video::ASPECT_FIT_ONLY,
+                Video::FULLSCREEN,
+                Video::NON_INTERACTIVE,
+
+                self::PROPERTY_PLAYBACK_MODE,
+                self::PROPERTY_CONTROLS,
+
+                self::PROPERTY_LIKE,
+                self::PROPERTY_COMMENTS
+            ],
+            $configuration
+        );
+        return $video_rule;
+    }
+
+    public function apply($transformer, $slideshow, $node)
+    {
+        $video = Video::create();
+
+        // Builds the image
+        $url = $this->getProperty(self::PROPERTY_VIDEO_URL, $node);
+        if ($url) {
+            $video->withURL($url);
+            $slideshow->addVideo($video);
+        } else {
+            $transformer->addWarning(
+                new InvalidSelector(
+                    self::PROPERTY_VIDEO_URL,
+                    $slideshow,
+                    $node,
+                    $this
+                )
+            );
+        }
+
+        $video_type = $this->getProperty(self::PROPERTY_VIDEO_TYPE, $node);
+        if ($video_type) {
+            $video->withContentType($video_type);
+        }
+
+        if ($this->getProperty(Video::ASPECT_FIT, $node)) {
+            $video->withPresentation(Video::ASPECT_FIT);
+        } elseif ($this->getProperty(Video::ASPECT_FIT_ONLY, $node)) {
+            $video->withPresentation(Video::ASPECT_FIT_ONLY);
+        } elseif ($this->getProperty(Video::FULLSCREEN, $node)) {
+            $video->withPresentation(Video::FULLSCREEN);
+        } elseif ($this->getProperty(Video::NON_INTERACTIVE, $node)) {
+            $video->withPresentation(Video::NON_INTERACTIVE);
+        }
+
+        if ($this->getProperty(self::PROPERTY_CONTROLS, $node)) {
+            $video->enableControls();
+        }
+
+        if ($this->getProperty(self::PROPERTY_PLAYBACK_MODE, $node)) {
+            $video->disableAutoplay();
+        }
+
+        if ($this->getProperty(self::PROPERTY_LIKE, $node)) {
+            $video->enableLike();
+        }
+
+        if ($this->getProperty(self::PROPERTY_COMMENTS, $node)) {
+            $video->enableComments();
+        }
+
+        $suppress_warnings = $transformer->suppress_warnings;
+        $transformer->suppress_warnings = true;
+        $transformer->transform($video, $node);
+        $transformer->suppress_warnings = $suppress_warnings;
+
+        return $slideshow;
+    }
+}

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example.html
@@ -73,6 +73,12 @@
         <figure>
           <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
         </figure>
+        <figure>
+          <video>
+            <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
+          </video>
+          <figcaption>This video is amazing.</figcaption>
+        </figure>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>


### PR DESCRIPTION
This PR

* [x] Adds Parsing skills to interpret videos within slideshows 
* [x] Adds test case for such a scenario like that
* [x] Created new rule to support this `SlideshowVideoRule`
* [x] Deprecates method `getArticleImages()`
