### PR TITLE
Added method getPlainText for TextContainer elements

### DIFF
--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -81,6 +81,27 @@ abstract class TextContainer extends Element implements Container
     }
 
     /**
+     * Build up a string with the content from children text container
+     *
+     * @return string the unformated plain text content from children
+     */
+    public function getPlainText()
+    {
+        $text = '';
+
+        // Generate markup
+        foreach ($this->textChildren as $content) {
+            if (Type::is($content, Type::STRING)) {
+                $text .= $content;
+            } else {
+                $text .= $content->getPlainText();
+            }
+        }
+
+        return $text;
+    }
+
+    /**
      * Overrides the Element::isValid().
      *
      * @see Element::isValid().

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -241,5 +241,4 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $rendered = $h1->getPlainText();
         $this->assertEquals($expected, $rendered);
     }
-
 }

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -223,4 +223,23 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $rendered = $h1->render();
         $this->assertEquals($expected, $rendered);
     }
+
+    public function testGetPlainText()
+    {
+        $h1 =
+            H1::create()
+                ->appendText(Bold::create()->appendText('Some'))
+                ->appendText(' text to be ')
+                ->appendText(Italic::create()->appendText('within'))
+                ->appendText(' a ')
+                ->appendText(Italic::create()->appendText('paragraph'))
+                ->appendText(' for ')
+                ->appendText(Bold::create()->appendText('testing.'));
+
+        $expected = 'Some text to be within a paragraph for testing.';
+
+        $rendered = $h1->getPlainText();
+        $this->assertEquals($expected, $rendered);
+    }
+
 }


### PR DESCRIPTION
This PR

* [x] Creates a method to get the plain text from text containers
* [x] Adds test for this usage
