### PR TITLE
Added small font size to Caption element

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -37,6 +37,7 @@ use Facebook\InstantArticles\Validators\Type;
 class Caption extends FormattedText
 {
     // Font size
+    const SIZE_SMALL = 'op-small';
     const SIZE_MEDIUM = 'op-medium';
     const SIZE_LARGE = 'op-large';
     const SIZE_XLARGE = 'op-extra-large';
@@ -72,7 +73,7 @@ class Caption extends FormattedText
     private $credit;
 
     /**
-     * @var string text Size. Values: "op-medium"|"op-large"|"op-extra-large"
+     * @var string text Size. Values: "op-small"|"op-medium"|"op-large"|"op-extra-large"
      */
     private $fontSize;
 
@@ -161,6 +162,7 @@ class Caption extends FormattedText
     /**
      * The Fontsize that will be used.
      *
+     * @see Caption::SIZE_SMALL
      * @see Caption::SIZE_MEDIUM
      * @see Caption::SIZE_LARGE
      * @see Caption::SIZE_XLARGE
@@ -176,7 +178,8 @@ class Caption extends FormattedText
             [
                 Caption::SIZE_XLARGE,
                 Caption::SIZE_LARGE,
-                Caption::SIZE_MEDIUM
+                Caption::SIZE_MEDIUM,
+                Caption::SIZE_SMALL
             ]
         );
         $this->fontSize = $font_size;
@@ -301,6 +304,7 @@ class Caption extends FormattedText
     /**
      * @return string the Font size.
      *
+     * @see Caption::SIZE_SMALL
      * @see Caption::SIZE_MEDIUM
      * @see Caption::SIZE_LARGE
      * @see Caption::SIZE_XLARGE

--- a/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/CaptionRule.php
@@ -53,6 +53,7 @@ class CaptionRule extends ConfigurationSelectorRule
                 Caption::ALIGN_CENTER,
                 Caption::ALIGN_RIGHT,
 
+                Caption::SIZE_SMALL,
                 Caption::SIZE_MEDIUM,
                 Caption::SIZE_LARGE,
                 Caption::SIZE_XLARGE,
@@ -90,6 +91,9 @@ class CaptionRule extends ConfigurationSelectorRule
             $caption->withTextAlignment(Caption::ALIGN_RIGHT);
         }
 
+        if ($this->getProperty(Caption::SIZE_SMALL, $node)) {
+            $caption->withFontsize(Caption::SIZE_SMALL);
+        }
         if ($this->getProperty(Caption::SIZE_MEDIUM, $node)) {
             $caption->withFontsize(Caption::SIZE_MEDIUM);
         }

--- a/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/H1Rule.php
@@ -41,6 +41,7 @@ class H1Rule extends ConfigurationSelectorRule
                 Caption::ALIGN_CENTER,
                 Caption::ALIGN_RIGHT,
 
+                Caption::SIZE_SMALL,
                 Caption::SIZE_MEDIUM,
                 Caption::SIZE_LARGE,
                 Caption::SIZE_XLARGE

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -85,7 +85,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    public function testRenderWithFontSize()
+    public function testRenderWithLargeFontSize()
     {
         $caption =
             Caption::create()
@@ -95,6 +95,22 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
         $expected =
             '<figcaption class="op-large">'.
                 'Caption Title'.
+            '</figcaption>';
+
+        $rendered = $caption->render();
+        $this->assertEquals($expected, $rendered);
+    }
+
+    public function testRenderWithSmallFontSize()
+    {
+        $caption =
+            Caption::create()
+                ->appendText('Small Caption Title')
+                ->withFontsize(Caption::SIZE_SMALL);
+
+        $expected =
+            '<figcaption class="op-small">'.
+                'Small Caption Title'.
             '</figcaption>';
 
         $rendered = $caption->render();


### PR DESCRIPTION
This PR

* Adds a new font size available value to the Caption element.
* Adds a new unit test to ensure the expected class `op-small` is added to the `<figcaption>` element.

Note: While this font size does NOT appear in the IA documentation, its existence can be verified in the IA Style Editor test article:

```html
<figure>
  <img src="http://fb.me/ia-img-subway_orange.jpg" />
  <figcaption class="op-small">
  ...
```


Also, the IA Style Editor shows the small size under the `Captions` menu:

![image](https://cloud.githubusercontent.com/assets/18663703/25408052/ab066556-29da-11e7-8ee1-c887d7fd6450.png)