### PR TITLE
Added getter for Caption Vertical Alignment

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -335,6 +335,18 @@ class Caption extends FormattedText
     }
 
     /**
+     * @return string the Vertical Alignment.
+     *
+     * @see Caption::VERTICAL_TOP
+     * @see Caption::VERTICAL_BOTTOM
+     * @see Caption::VERTICAL_CENTER
+     */
+    public function getVerticalAlignment()
+    {
+        return $this->verticalAlignment;
+    }
+
+    /**
      * Structure and create the full ArticleImage in a XML format DOMElement.
      *
      * @param \DOMDocument $document where this element will be appended. Optional


### PR DESCRIPTION
This PR

* Adds a simple getter to the Caption Vertical Alignment

Note: Since the implementation is trivial and the rest of the class getters do not have explicit test coverage, I am NOT adding unit tests.