### PR TITLE
Fix on Map script selector

### DIFF
--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -534,7 +534,7 @@
             },
             {
                 "class": "GeoTagRule",
-                "selector" : "script.op-geotag",
+                "selector" : "script",
                 "properties" : {
                     "map.geotag" : {
                         "type" : "string",


### PR DESCRIPTION
This removes the class selector, since the class on the script tag is not required, thus this makes it compatible with more generated formats.
* [x] Removes class from script tag selector