### PR TITLE
Get Author name from address text

### DIFF
--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -248,6 +248,15 @@
             },
             {
                 "class": "AuthorRule",
+                "selector" : "address",
+                "properties" : {
+                    "author.name" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            {
+                "class": "AuthorRule",
                 "selector" : "//header/address[a]",
                 "properties" : {
                     "author.url" : {
@@ -267,15 +276,6 @@
                     "author.description" : {
                         "type" : "sibling",
                         "selector" : "a"
-                    }
-                }
-            },
-            {
-                "class": "AuthorRule",
-                "selector" : "//header/address[not(a)]",
-                "properties" : {
-                    "author.name" : {
-                        "type" : "string"
                     }
                 }
             },

--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -248,7 +248,7 @@
             },
             {
                 "class": "AuthorRule",
-                "selector" : "address",
+                "selector" : "//header/address[a]",
                 "properties" : {
                     "author.url" : {
                         "type" : "string",
@@ -267,6 +267,15 @@
                     "author.description" : {
                         "type" : "sibling",
                         "selector" : "a"
+                    }
+                }
+            },
+            {
+                "class": "AuthorRule",
+                "selector" : "//header/address[not(a)]",
+                "properties" : {
+                    "author.name" : {
+                        "type" : "string"
                     }
                 }
             },

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -8,6 +8,8 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
+use Facebook\InstantArticles\Parser\Parser;
+
 class AuthorRuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateFromProperties()
@@ -52,5 +54,39 @@ class AuthorRuleTest extends \PHPUnit_Framework_TestCase
                 ]
             );
         $this->assertEquals(get_class($author_rule), AuthorRule::getClassName());
+    }
+
+    public function testExpectedNameWithLink()
+    {
+        $expectedName = "The Author";
+        $html =
+            '<header>'.
+                '<h1>Article Title</h1>'.
+                // The name is inside an <a> element
+                "<address><a>$expectedName</a></address>".
+            '</header>';
+
+        $parser = new Parser();
+        $instantArticle = $parser->parse($html);
+        $author = $instantArticle->getHeader()->getAuthors()[0];
+
+        $this->assertEquals($expectedName, $author->getName());
+    }
+
+    public function testExpectedNameWithoutLink()
+    {
+        $expectedName = "The Other Author";
+        $html =
+            '<header>'.
+                '<h1>Article Title</h1>'.
+                // The name is inside the <address> element
+                "<address>$expectedName</address>".
+            '</header>';
+
+        $parser = new Parser();
+        $instantArticle = $parser->parse($html);
+        $author = $instantArticle->getHeader()->getAuthors()[0];
+
+        $this->assertEquals($expectedName, $author->getName());
     }
 }


### PR DESCRIPTION
This PR

* [x] Allows Author names to be parsed from the `<address>` node text (when it has no `<a>` descendant), which is also supported in IA.
* [x] Updates the selector to enforce the `<address>` to be a descendant of the `<header>` element.
* [x] Adds unit tests to parse author names with and without `<a>` nodes.

