### PR TITLE
Type::IsTextEmpty bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,31 @@ The SDK consists of three components:
 - **Client**: A simple wrapper around the [Instant Articles API](https://developers.facebook.com/docs/instant-articles/api), which can be used for publishing Instant Articles on Facebook. The client provides a CRUD interface for Instant Articles as well as a helper for authentication. The client depends on the main [Facebook SDK for PHP](https://github.com/facebook/facebook-php-sdk-v4) as an interface to the Graph API and Facebook Login.
 
 ## Quick Start
-You can find examples on how to use the different components of this SDK to integrate with your CMS in the [Getting Started section](https://developers.facebook.com/docs/instant-articles/sdk/#getting-started) of the documentation.
 
-## Installation
-
-The Facebook Instant Articles PHP SDK can be installed with [Composer](https://getcomposer.org/). Run this command:
+The Facebook Instant Articles PHP SDK can be installed with the [Composer](https://getcomposer.org/) dependency manager by running this command on your project's root folder:
 
 ```sh
-composer require facebook/facebook-instant-articles-sdk-php
+$ composer require facebook/facebook-instant-articles-sdk-php
 ```
 
-## Testing and Developing ##
+After the installation, you can include the auto loader script in your source with:
 
-[Composer](https://getcomposer.org/) is a prerequisite for testing and developing. [Install composer globally](https://getcomposer.org/doc/00-intro.md#globally), then install project dependencies by running this command in the project root directory:
+```PHP
+require_once('vendor/autoload.php');
+```
+
+## Official Documentation
+You can find examples on how to use the different components of this SDK to integrate it with your CMS in the [Getting Started](https://developers.facebook.com/docs/instant-articles/sdk/#getting-started) section of the documentation.
+
+## Contributing
+
+Clone the repository
+```sh
+$ git clone https://github.com/facebook/facebook-instant-articles-sdk-php.git
+```
+
+[Composer](https://getcomposer.org/) is a prerequisite for testing and developing. [Install composer globally](https://getcomposer.org/doc/00-intro.md#globally), then install project dependencies by running this command in the project's root directory:
+
 ```sh
 $ composer install
 ```
@@ -53,6 +65,10 @@ If you change structure, paths, namespaces, etc., make sure you run the [autoloa
 $ composer dump-autoload
 ```
 
+___
+**For us to accept contributions you will have to first sign the [Contributor License Agreement](https://code.facebook.com/cla). Please see [CONTRIBUTING](https://github.com/facebook/facebook-instant-articles-sdk-php/blob/master/CONTRIBUTING.md) for details.**
+___
+
 ## Troubleshooting
 
 If you are encountering problems, the following tips may help in troubleshooting issues:
@@ -64,10 +80,6 @@ If you are encountering problems, the following tips may help in troubleshooting
 - Set the `threshold` in the [configuration of the Logger](https://logging.apache.org/log4php/docs/configuration.html#PHP) to `DEBUG` to expose more details about the items processed by the Transformer.
 
 - Refer to the existing [tests of the `Elements`](https://github.com/facebook/facebook-instant-articles-sdk-php/tree/master/tests/Facebook/InstantArticles/Elements) for examples of what is required of each and to potentially create your own tests (which can be run with `$ composer test`).
-
-## Contributing
-
-For us to accept contributions you will have to first have signed the [Contributor License Agreement](https://code.facebook.com/cla). Please see [CONTRIBUTING](https://github.com/facebook/facebook-instant-articles-sdk-php/blob/master/CONTRIBUTING.md) for details.
 
 ## License
 

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -41,6 +41,15 @@ abstract class TextContainer extends Element implements Container
     }
 
     /**
+     * Clears the text.
+     *
+     */
+    public function clearText()
+    {
+        $this->textChildren = [];
+    }
+
+    /**
      * @return string[]|FormattedText[]|TextContainer[] All text token for this text container.
      */
     public function getTextChildren()

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -398,7 +398,6 @@ class Type
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines
-        //$test = strip_tags($text);
         $text = preg_replace("/\s+/", "", $text);
         $text = str_replace("&nbsp;", "", $text);
         $text = str_replace("<br>", "", $text);

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -386,19 +386,23 @@ class Type
      * "\n" => true
      * "a" => false
      * "  a  " => false
+     * "&nbsp;" => true
+     * "<br>" => true
      *
      * @param string $text The text that will be checked.
      * @return true if empty, false otherwise.
      */
     public static function isTextEmpty($text)
     {
-        if (!isset($text) || $text === null || !self::is($text, self::STRING)) {
+        if ($text === null || !self::is($text, self::STRING)) {
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines
-        $text = strip_tags($text);
-        $text = preg_replace("/[\r\n\s]+/", "", $text);
+        //$test = strip_tags($text);
+        $text = preg_replace("/\s+/", "", $text);
         $text = str_replace("&nbsp;", "", $text);
+        $text = str_replace("<br>", "", $text);
+        $text = str_replace("<br/>", "", $text);
 
         return empty($text);
     }

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -394,7 +394,7 @@ class Type
      */
     public static function isTextEmpty($text)
     {
-        if ($text === null || !self::is($text, self::STRING)) {
+        if (!isset($text) || $text === null || !self::is($text, self::STRING)) {
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -42,13 +42,13 @@ class ImageTest extends \PHPUnit_Framework_TestCase
                 ->withURL('https://jpeg.org/images/jpegls-home.jpg')
                 ->withCaption(
                     Caption::create()
-                        ->appendText('Some caption to the image')
+                        ->appendText('<3 some caption to the image')
                 );
 
         $expected =
             '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
-                '<figcaption>Some caption to the image</figcaption>'.
+                '<figcaption>&lt;3 some caption to the image</figcaption>'.
             '</figure>';
 
         $rendered = $image->render();

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -340,15 +340,18 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Type::isTextEmpty("\nnot empty\t"));
         $this->assertFalse(Type::isTextEmpty(" not empty "));
         $this->assertFalse(Type::isTextEmpty("&nbsp;not empty"));
+        $this->assertFalse(Type::isTextEmpty("<3 strings"));
     }
 
     public function testStringEmpty()
     {
         $this->assertTrue(Type::isTextEmpty(""));
         $this->assertTrue(Type::isTextEmpty("  "));
-        $this->assertTrue(Type::isTextEmpty("\t\t"));
+        $this->assertTrue(Type::isTextEmpty("\t\n\r"));
         $this->assertTrue(Type::isTextEmpty("&nbsp;"));
         $this->assertTrue(Type::isTextEmpty("\n"));
+        $this->assertTrue(Type::isTextEmpty("<br       >"));
+        $this->assertTrue(Type::isTextEmpty("<br />"));
     }
 
     public function testEnforceElementTag()


### PR DESCRIPTION
Elements that have text like Paragraph, Caption, etc that inherit from TextContainer were affected by this bug.

The problem was that TextContainer::isValid() calls Type::isTextEmpty() and that function had strip_tags($text) that was removing valid captions like `"<3 this sdk"
`. It would interpret this string as an html tag and remove the entire line.

I included `<br>` as a "blank character" too, following the trend of `nbsp;` and tweaked the regex.

Also updated some tests too.

