### PR TITLE
Fix istextempty

### DIFF
--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -41,6 +41,15 @@ abstract class TextContainer extends Element implements Container
     }
 
     /**
+     * Clears the text.
+     *
+     */
+    public function clearText()
+    {
+        $this->textChildren = [];
+    }
+
+    /**
      * @return string[]|FormattedText[]|TextContainer[] All text token for this text container.
      */
     public function getTextChildren()

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -23,7 +23,7 @@ abstract class TextContainer extends Element implements Container
     /**
      * @var array The content is a list of strings and FormattingElements
      */
-    private $textChildren = [];
+    private $textChildren = array();
 
     /**
      * Adds content to the formatted text.
@@ -42,11 +42,10 @@ abstract class TextContainer extends Element implements Container
 
     /**
      * Clears the text.
-     *
      */
     public function clearText()
     {
-        $this->textChildren = [];
+        $this->textChildren = array();
     }
 
     /**

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -398,7 +398,6 @@ class Type
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines
-        //$test = strip_tags($text);
         $text = preg_replace("/\s+/", "", $text);
         $text = str_replace("&nbsp;", "", $text);
         $text = str_replace("<br>", "", $text);

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -386,19 +386,23 @@ class Type
      * "\n" => true
      * "a" => false
      * "  a  " => false
+     * "&nbsp;" => true
+     * "<br>" => true
      *
      * @param string $text The text that will be checked.
      * @return true if empty, false otherwise.
      */
     public static function isTextEmpty($text)
     {
-        if (!isset($text) || $text === null || !self::is($text, self::STRING)) {
+        if ($text === null || !self::is($text, self::STRING)) {
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines
-        $text = strip_tags($text);
-        $text = preg_replace("/[\r\n\s]+/", "", $text);
+        //$test = strip_tags($text);
+        $text = preg_replace("/\s+/", "", $text);
         $text = str_replace("&nbsp;", "", $text);
+        $text = str_replace("<br>", "", $text);
+        $text = str_replace("<br/>", "", $text);
 
         return empty($text);
     }

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -394,7 +394,7 @@ class Type
      */
     public static function isTextEmpty($text)
     {
-        if ($text === null || !self::is($text, self::STRING)) {
+        if (!isset($text) || $text === null || !self::is($text, self::STRING)) {
             return true;
         }
         // Stripes empty spaces, &nbsp;, <br/>, new lines

--- a/src/Facebook/InstantArticles/Validators/Type.php
+++ b/src/Facebook/InstantArticles/Validators/Type.php
@@ -387,7 +387,6 @@ class Type
      * "a" => false
      * "  a  " => false
      * "&nbsp;" => true
-     * "<br>" => true
      *
      * @param string $text The text that will be checked.
      * @return true if empty, false otherwise.
@@ -400,8 +399,6 @@ class Type
         // Stripes empty spaces, &nbsp;, <br/>, new lines
         $text = preg_replace("/\s+/", "", $text);
         $text = str_replace("&nbsp;", "", $text);
-        $text = str_replace("<br>", "", $text);
-        $text = str_replace("<br/>", "", $text);
 
         return empty($text);
     }

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -42,13 +42,13 @@ class ImageTest extends \PHPUnit_Framework_TestCase
                 ->withURL('https://jpeg.org/images/jpegls-home.jpg')
                 ->withCaption(
                     Caption::create()
-                        ->appendText('Some caption to the image')
+                        ->appendText('<3 some caption to the image')
                 );
 
         $expected =
             '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
-                '<figcaption>Some caption to the image</figcaption>'.
+                '<figcaption>&lt;3 some caption to the image</figcaption>'.
             '</figure>';
 
         $rendered = $image->render();

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -340,15 +340,18 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Type::isTextEmpty("\nnot empty\t"));
         $this->assertFalse(Type::isTextEmpty(" not empty "));
         $this->assertFalse(Type::isTextEmpty("&nbsp;not empty"));
+        $this->assertFalse(Type::isTextEmpty("<3 strings"));
     }
 
     public function testStringEmpty()
     {
         $this->assertTrue(Type::isTextEmpty(""));
         $this->assertTrue(Type::isTextEmpty("  "));
-        $this->assertTrue(Type::isTextEmpty("\t\t"));
+        $this->assertTrue(Type::isTextEmpty("\t\n\r"));
         $this->assertTrue(Type::isTextEmpty("&nbsp;"));
         $this->assertTrue(Type::isTextEmpty("\n"));
+        $this->assertTrue(Type::isTextEmpty("<br       >"));
+        $this->assertTrue(Type::isTextEmpty("<br />"));
     }
 
     public function testEnforceElementTag()

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -341,6 +341,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Type::isTextEmpty(" not empty "));
         $this->assertFalse(Type::isTextEmpty("&nbsp;not empty"));
         $this->assertFalse(Type::isTextEmpty("<3 strings"));
+        $this->assertFalse(Type::isTextEmpty("<br />"));
     }
 
     public function testStringEmpty()
@@ -350,8 +351,6 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Type::isTextEmpty("\t\n\r"));
         $this->assertTrue(Type::isTextEmpty("&nbsp;"));
         $this->assertTrue(Type::isTextEmpty("\n"));
-        $this->assertTrue(Type::isTextEmpty("<br       >"));
-        $this->assertTrue(Type::isTextEmpty("<br />"));
     }
 
     public function testEnforceElementTag()


### PR DESCRIPTION
Elements that have text like Paragraph, Caption, etc that inherit from TextContainer were affected by this bug.

The problem was that TextContainer::isValid() calls Type::isTextEmpty() and that function had strip_tags($text) that was removing valid captions like "<3 this sdk". It would interpret this string as an html tag and remove the entire line.

I included <br> as a "blank character" too, following the trend of nbsp; and tweaked the regex.

Also updated some tests too.
