### PR TITLE
Fix timezone

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Analytics.php
+++ b/src/Facebook/InstantArticles/Elements/Analytics.php
@@ -45,7 +45,7 @@ class Analytics extends ElementWithHTML
     }
 
     /**
-     * Sets the source for the ad.
+     * Sets the source for the analytics.
      *
      * @param string $source The source of the content for your ad.
      *

--- a/src/Facebook/InstantArticles/Parser/Parser.php
+++ b/src/Facebook/InstantArticles/Parser/Parser.php
@@ -14,12 +14,14 @@ use Facebook\InstantArticles\Validators\Type;
 
 class Parser
 {
+
     /**
      * @param string|DOMDocument $document The document html of an Instant Article
+     * @param Transformer $transformer The Transformer instance to use. A fresh one will be created by default.
      *
      * @return InstantArticle filled element that was parsed from the DOMDocument parameter
      */
-    public function parse($content)
+    public function parse($content, $transformer = null)
     {
         if (Type::is($content, Type::STRING)) {
             libxml_use_internal_errors(true);
@@ -33,9 +35,11 @@ class Parser
         $json_file = file_get_contents(__DIR__ . '/instant-articles-rules.json');
 
         $instant_article = InstantArticle::create();
-        $transformer = new Transformer();
-        $transformer->loadRules($json_file);
 
+        if ($transformer === null) {
+            $transformer = new Transformer();
+        }
+        $transformer->loadRules($json_file);
         $transformer->transform($instant_article, $document);
 
         return $instant_article;

--- a/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
@@ -12,6 +12,13 @@ use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
+/**
+ * Rule to parse dates from the document.
+ *
+ * The time zone used will be the default time zone defined on the Transformer.
+ *
+ * @see Transformer::getDefaultDateTimeZone()
+ */
 class TimeRule extends ConfigurationSelectorRule
 {
     const PROPERTY_TIME_TYPE_DEPRECATED = 'article.time_type';
@@ -62,7 +69,7 @@ class TimeRule extends ConfigurationSelectorRule
         $time_string = $this->getProperty(self::PROPERTY_TIME, $node);
         if ($time_string) {
             $time = Time::create($this->type);
-            $time->withDatetime(new \DateTime($time_string, new \DateTimeZone('America/Los_Angeles')));
+            $time->withDatetime(new \DateTime($time_string, $transformer->getDefaultDateTimeZone()));
             $header->withTime($time);
         } else {
             $transformer->addWarning(

--- a/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/TimeRule.php
@@ -62,7 +62,7 @@ class TimeRule extends ConfigurationSelectorRule
         $time_string = $this->getProperty(self::PROPERTY_TIME, $node);
         if ($time_string) {
             $time = Time::create($this->type);
-            $time->withDatetime(new \DateTime($time_string));
+            $time->withDatetime(new \DateTime($time_string, new \DateTimeZone('America/Los_Angeles')));
             $header->withTime($time);
         } else {
             $transformer->addWarning(

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -47,10 +47,23 @@ class Transformer
     private $instantArticle;
 
     /**
+     * @var DateTimeZone the timezone for parsing dates. It defaults to 'America/Los_Angeles', but can be customized.
+     */
+    private $defaultDateTimeZone;
+
+    /**
      * Flag attribute added to elements processed by a getter, so they
      * are not processed again by other rules.
      */
     const INSTANT_ARTICLES_PARSED_FLAG = 'data-instant-articles-element-processed';
+
+    /**
+     * Initializes default values.
+     */
+    public function __construct()
+    {
+        $this->defaultDateTimeZone = new \DateTimeZone('America/Los_Angeles');
+    }
 
     /**
      * Clones a node for appending to raw-html containing Elements like Interactive.
@@ -337,7 +350,7 @@ class Transformer
     /**
      * Overrides all rules already set in this transformer instance.
      *
-     * @return Rule[] List of configured rules.
+     * @param Rule[] $rules List of configured rules.
      */
     public function setRules($rules)
     {
@@ -348,5 +361,26 @@ class Transformer
         foreach ($rules as $rule) {
             $this->addRule($rule);
         }
+    }
+
+    /**
+     * Sets the default timezone for parsing dates.
+     *
+     * @param DateTimeZone $dateTimeZone
+     */
+    public function setDefaultDateTimeZone($dateTimeZone)
+    {
+        Type::enforce($dateTimeZone, 'DateTimeZone');
+        $this->defaultDateTimeZone = $dateTimeZone;
+    }
+
+    /**
+     * Gets the default timezone for parsing dates.
+     *
+     * @return DateTimeZone
+     */
+    public function getDefaultDateTimeZone()
+    {
+        return $this->defaultDateTimeZone;
     }
 }

--- a/tests/Facebook/InstantArticles/Parser/ParserTest.php
+++ b/tests/Facebook/InstantArticles/Parser/ParserTest.php
@@ -60,4 +60,18 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($html_file, $result);
     }
+    
+    public function testSelfParseStringNoTimezone()
+    {
+        $html_file_no_timezone = file_get_contents(__DIR__ . '/instant-article-example-no-timezone.html');
+        $html_file_standard_timezone = file_get_contents(__DIR__ . '/instant-article-example-standard-timezone.html');
+
+        $parser = new Parser();
+        $instant_article = $parser->parse($html_file_no_timezone);
+        $instant_article->addMetaProperty('op:generator:version', '1.0.0');
+        $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
+        $result = $instant_article->render('', true)."\n";
+
+        $this->assertEquals($html_file_standard_timezone, $result);
+    }
 }

--- a/tests/Facebook/InstantArticles/Parser/ParserTest.php
+++ b/tests/Facebook/InstantArticles/Parser/ParserTest.php
@@ -8,6 +8,8 @@
  */
 namespace Facebook\InstantArticles\Parser;
 
+use Facebook\InstantArticles\Transformer\Transformer;
+
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
@@ -60,7 +62,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($html_file, $result);
     }
-    
+
     public function testSelfParseStringNoTimezone()
     {
         $html_file_no_timezone = file_get_contents(__DIR__ . '/instant-article-example-no-timezone.html');
@@ -68,6 +70,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $parser = new Parser();
         $instant_article = $parser->parse($html_file_no_timezone);
+        $instant_article->addMetaProperty('op:generator:version', '1.0.0');
+        $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
+        $result = $instant_article->render('', true)."\n";
+
+        $this->assertEquals($html_file_standard_timezone, $result);
+    }
+
+    public function testSelfParseStringNoTimezoneWithDefaultNYC()
+    {
+        $html_file_no_timezone = file_get_contents(__DIR__ . '/instant-article-example-no-timezone.html');
+        $html_file_standard_timezone = file_get_contents(__DIR__ . '/instant-article-example-nyc-timezone.html');
+
+        $transformer = new Transformer();
+        $transformer->setDefaultDateTimeZone(new \DateTimeZone('America/New_York'));
+
+        $parser = new Parser();
+        $instant_article = $parser->parse($html_file_no_timezone, $transformer);
         $instant_article->addMetaProperty('op:generator:version', '1.0.0');
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-no-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-no-timezone.html
@@ -1,0 +1,199 @@
+<html>
+  <head>
+    <link rel="canonical" href="http://foo.com/article.html"/>
+    <meta charset="utf-8"/>
+    <meta property="op:generator" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:version" content="1.0.0"/>
+    <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:transformer:version" content="1.0.0"/>
+    <meta property="op:markup_version" content="v1.0"/>
+  </head>
+  <body>
+    <article>
+      <header>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+          <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        </figure>
+        <h1>Big Top <b>Title</b></h1>
+        <h2>Smaller <b>SubTitle</b></h2>
+        <time class="op-published" datetime="1984-08-14T19:30:00">August 14th, 7:30pm</time>
+        <time class="op-modified" datetime="2016-02-10T10:00:00">February 10th, 10:00am</time>
+        <address><a href="#" title="Title of author">Author Name</a>
+          Author more detailed description
+          Even more
+        </address>
+        <address><a href="http://facebook.com/author" rel="facebook">Author in FB</a>
+          Author user in facebook
+        </address>
+        <address><a title="PHP Programmer">Developer</a>
+        </address>
+        <h3 class="op-kicker">Some kicker of this article</h3>
+      </header>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure data-feedback="fb:likes">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:comments">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [23.166667, 89.216667]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:likes,fb:comments">
+        <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+      </figure>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-slideshow">
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home2.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
+        </figure>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <ol>
+        <li>First list item</li>
+        <li>One paragraph on the list</li>
+        <li>On the span</li>
+        <li>Text inside div?</li>
+        <li>Other <a href="#">paragraph</a> on the li</li>
+        <li>Last list item</li>
+      </ol>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure class="op-interactive">
+        <iframe src="http://example.com/custom-interactive" class="column-width" height="60">
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+        <figcaption>This graphic is awesome.</figcaption>
+      </figure>
+      <figure class="op-ad">
+        <iframe src="http://foo.com"></iframe>
+      </figure>
+      <blockquote>Some blockquotes creates <b>magic</b> in an article</blockquote>
+      <figure class="op-map">
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry":
+              {
+                "type": "Point",
+                "coordinates": [23.166667, 89.216667]
+              },
+            "properties":
+              {
+                "title": "Jessore, Bangladesh",
+                "radius": 750000,
+                "pivot": true,
+                "style": "satellite",
+              }
+           }
+        </script>
+        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">title for caption</h1><h2 class="op-vertical-below op-right">sub title for caption</h2>
+
+
+        <cite class="op-vertical-center op-left">credit within caption</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <aside>
+        We can be more efficient about where we grow, what we grow, and how we grow.
+        <cite>Fruit Store Company</cite></aside>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Tracker with enclosing on the script</h1>
+          <div><script>alert("test & more test");</script></div>
+        </iframe>
+      </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <h1>Custom code for your social embed</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+        <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
+          <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
+        </video>
+        <figcaption class="op-vertical-below"><h1>Video 1 Title</h1>
+
+          <cite>Attribution Source</cite></figcaption>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [ [23.166667, 89.216667], [23.166667, 89.216667] ]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+      </figure>
+      <ul class="op-related-articles" title="The related ones in the middle">
+        <li>
+          <a href="http://example.com/article.html"></a>
+        </li>
+        <li data-sponsored="true">
+          <a href="http://example.com/sponsored-article.html"></a>
+        </li>
+        <li>
+          <a href="http://example.com/another-article.html"></a>
+        </li>
+      </ul>
+      <footer>
+        <aside>
+          <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
+          <p>Paragraph text as credits</p>
+        </aside>
+        <ul class="op-related-articles">
+          <li>
+            <a href="http://example.com/article.html"></a>
+          </li>
+          <li data-sponsored="true">
+            <a href="http://example.com/sponsored-article.html"></a>
+          </li>
+          <li>
+            <a href="http://example.com/another-article.html"></a>
+          </li>
+        </ul>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-nyc-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-nyc-timezone.html
@@ -1,0 +1,199 @@
+<html>
+  <head>
+    <link rel="canonical" href="http://foo.com/article.html"/>
+    <meta charset="utf-8"/>
+    <meta property="op:generator" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:version" content="1.0.0"/>
+    <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:transformer:version" content="1.0.0"/>
+    <meta property="op:markup_version" content="v1.0"/>
+  </head>
+  <body>
+    <article>
+      <header>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+          <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        </figure>
+        <h1>Big Top <b>Title</b></h1>
+        <h2>Smaller <b>SubTitle</b></h2>
+        <time class="op-published" datetime="1984-08-14T19:30:00-04:00">August 14th, 7:30pm</time>
+        <time class="op-modified" datetime="2016-02-10T10:00:00-05:00">February 10th, 10:00am</time>
+        <address><a href="#" title="Title of author">Author Name</a>
+          Author more detailed description
+          Even more
+        </address>
+        <address><a href="http://facebook.com/author" rel="facebook">Author in FB</a>
+          Author user in facebook
+        </address>
+        <address><a title="PHP Programmer">Developer</a>
+        </address>
+        <h3 class="op-kicker">Some kicker of this article</h3>
+      </header>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure data-feedback="fb:likes">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:comments">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [23.166667, 89.216667]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:likes,fb:comments">
+        <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+      </figure>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-slideshow">
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home2.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
+        </figure>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <ol>
+        <li>First list item</li>
+        <li>One paragraph on the list</li>
+        <li>On the span</li>
+        <li>Text inside div?</li>
+        <li>Other <a href="#">paragraph</a> on the li</li>
+        <li>Last list item</li>
+      </ol>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure class="op-interactive">
+        <iframe src="http://example.com/custom-interactive" class="column-width" height="60">
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+        <figcaption>This graphic is awesome.</figcaption>
+      </figure>
+      <figure class="op-ad">
+        <iframe src="http://foo.com"></iframe>
+      </figure>
+      <blockquote>Some blockquotes creates <b>magic</b> in an article</blockquote>
+      <figure class="op-map">
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry":
+              {
+                "type": "Point",
+                "coordinates": [23.166667, 89.216667]
+              },
+            "properties":
+              {
+                "title": "Jessore, Bangladesh",
+                "radius": 750000,
+                "pivot": true,
+                "style": "satellite",
+              }
+           }
+        </script>
+        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">title for caption</h1><h2 class="op-vertical-below op-right">sub title for caption</h2>
+
+
+        <cite class="op-vertical-center op-left">credit within caption</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <aside>
+        We can be more efficient about where we grow, what we grow, and how we grow.
+        <cite>Fruit Store Company</cite></aside>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Tracker with enclosing on the script</h1>
+          <div><script>alert("test & more test");</script></div>
+        </iframe>
+      </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <h1>Custom code for your social embed</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+        <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
+          <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
+        </video>
+        <figcaption class="op-vertical-below"><h1>Video 1 Title</h1>
+
+          <cite>Attribution Source</cite></figcaption>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [ [23.166667, 89.216667], [23.166667, 89.216667] ]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+      </figure>
+      <ul class="op-related-articles" title="The related ones in the middle">
+        <li>
+          <a href="http://example.com/article.html"></a>
+        </li>
+        <li data-sponsored="true">
+          <a href="http://example.com/sponsored-article.html"></a>
+        </li>
+        <li>
+          <a href="http://example.com/another-article.html"></a>
+        </li>
+      </ul>
+      <footer>
+        <aside>
+          <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
+          <p>Paragraph text as credits</p>
+        </aside>
+        <ul class="op-related-articles">
+          <li>
+            <a href="http://example.com/article.html"></a>
+          </li>
+          <li data-sponsored="true">
+            <a href="http://example.com/sponsored-article.html"></a>
+          </li>
+          <li>
+            <a href="http://example.com/another-article.html"></a>
+          </li>
+        </ul>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-standard-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-standard-timezone.html
@@ -1,0 +1,199 @@
+<html>
+  <head>
+    <link rel="canonical" href="http://foo.com/article.html"/>
+    <meta charset="utf-8"/>
+    <meta property="op:generator" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:version" content="1.0.0"/>
+    <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:transformer:version" content="1.0.0"/>
+    <meta property="op:markup_version" content="v1.0"/>
+  </head>
+  <body>
+    <article>
+      <header>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+          <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        </figure>
+        <h1>Big Top <b>Title</b></h1>
+        <h2>Smaller <b>SubTitle</b></h2>
+        <time class="op-published" datetime="1984-08-14T19:30:00-07:00">August 14th, 7:30pm</time>
+        <time class="op-modified" datetime="2016-02-10T10:00:00-08:00">February 10th, 10:00am</time>
+        <address><a href="#" title="Title of author">Author Name</a>
+          Author more detailed description
+          Even more
+        </address>
+        <address><a href="http://facebook.com/author" rel="facebook">Author in FB</a>
+          Author user in facebook
+        </address>
+        <address><a title="PHP Programmer">Developer</a>
+        </address>
+        <h3 class="op-kicker">Some kicker of this article</h3>
+      </header>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure data-feedback="fb:likes">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:comments">
+        <img src="http://mydomain.com/path/to/img.jpg"/>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [23.166667, 89.216667]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <figure data-feedback="fb:likes,fb:comments">
+        <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+      </figure>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-slideshow">
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home2.jpg"/>
+        </figure>
+        <figure>
+          <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
+        </figure>
+        <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <ol>
+        <li>First list item</li>
+        <li>One paragraph on the list</li>
+        <li>On the span</li>
+        <li>Text inside div?</li>
+        <li>Other <a href="#">paragraph</a> on the li</li>
+        <li>Last list item</li>
+      </ol>
+      <p>Some text to be within a paragraph for testing.</p>
+      <figure class="op-interactive">
+        <iframe src="http://example.com/custom-interactive" class="column-width" height="60">
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+        <figcaption>This graphic is awesome.</figcaption>
+      </figure>
+      <figure class="op-ad">
+        <iframe src="http://foo.com"></iframe>
+      </figure>
+      <blockquote>Some blockquotes creates <b>magic</b> in an article</blockquote>
+      <figure class="op-map">
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry":
+              {
+                "type": "Point",
+                "coordinates": [23.166667, 89.216667]
+              },
+            "properties":
+              {
+                "title": "Jessore, Bangladesh",
+                "radius": 750000,
+                "pivot": true,
+                "style": "satellite",
+              }
+           }
+        </script>
+        <figcaption class="op-vertical-above"><h1 class="op-vertical-above op-center">title for caption</h1><h2 class="op-vertical-below op-right">sub title for caption</h2>
+
+
+        <cite class="op-vertical-center op-left">credit within caption</cite></figcaption>
+        <audio title="audio title" autoplay="autoplay" muted="muted">
+          <source src="http://foo.com/mp3"/>
+        </audio>
+      </figure>
+      <aside>
+        We can be more efficient about where we grow, what we grow, and how we grow.
+        <cite>Fruit Store Company</cite></aside>
+      <p>Other text to be within a second paragraph for testing.</p>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Some custom code</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure class="op-tracker">
+        <iframe>
+          <h1>Tracker with enclosing on the script</h1>
+          <div><script>alert("test & more test");</script></div>
+        </iframe>
+      </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <h1>Custom code for your social embed</h1>
+          <script>alert("test & more test");</script></iframe>
+      </figure>
+      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+        <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
+          <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
+        </video>
+        <figcaption class="op-vertical-below"><h1>Video 1 Title</h1>
+
+          <cite>Attribution Source</cite></figcaption>
+        <script type="application/json" class="op-geotag">
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [ [23.166667, 89.216667], [23.166667, 89.216667] ]
+            },
+            "properties": {
+              "title": "Jessore, Bangladesh",
+              "radius": 750000,
+              "pivot": true,
+              "style": "satellite",
+            }
+          }
+        </script>
+      </figure>
+      <ul class="op-related-articles" title="The related ones in the middle">
+        <li>
+          <a href="http://example.com/article.html"></a>
+        </li>
+        <li data-sponsored="true">
+          <a href="http://example.com/sponsored-article.html"></a>
+        </li>
+        <li>
+          <a href="http://example.com/another-article.html"></a>
+        </li>
+      </ul>
+      <footer>
+        <aside>
+          <p>Some plaintext credits to<a href="http://facebook.com/author" rel="facebook">Author</a></p>
+          <p>Paragraph text as credits</p>
+        </aside>
+        <ul class="op-related-articles">
+          <li>
+            <a href="http://example.com/article.html"></a>
+          </li>
+          <li data-sponsored="true">
+            <a href="http://example.com/sponsored-article.html"></a>
+          </li>
+          <li>
+            <a href="http://example.com/another-article.html"></a>
+          </li>
+        </ul>
+      </footer>
+    </article>
+  </body>
+</html>


### PR DESCRIPTION
This PR fixes an issue where the parser would rely on the local machine time when parsing dates without a provided timezone. We'll now default to Pacific Time, which is the same behavior as the Instant Articles back-end.