### PR TITLE
Fix: Run build on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7
+    - php: 7.1
       env: WITH_CS=true
 
 cache:


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 to the Travis build matrix