### PR TITLE
Fix: Interface implementation already announced

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -33,7 +33,7 @@ use Facebook\InstantArticles\Validators\Type;
  * @see Map
  * @see {link:https://developers.intern.facebook.com/docs/instant-articles/reference/image}
  */
-class Image extends Audible implements ChildrenContainer
+class Image extends Audible
 {
     const ASPECT_FIT = 'aspect-fit';
     const ASPECT_FIT_ONLY = 'aspect-fit-only';

--- a/src/Facebook/InstantArticles/Elements/Map.php
+++ b/src/Facebook/InstantArticles/Elements/Map.php
@@ -34,7 +34,7 @@ use Facebook\InstantArticles\Validators\Type;
  *  </figure>
  *
  */
-class Map extends Audible implements ChildrenContainer
+class Map extends Audible
 {
     /**
      * @var Caption The caption for Image

--- a/src/Facebook/InstantArticles/Elements/Slideshow.php
+++ b/src/Facebook/InstantArticles/Elements/Slideshow.php
@@ -29,7 +29,7 @@ use Facebook\InstantArticles\Validators\Type;
  *
  * @see {link:https://developers.intern.facebook.com/docs/instant-articles/reference/image}
  */
-class Slideshow extends Audible implements ChildrenContainer
+class Slideshow extends Audible
 {
     /**
      * @var Caption The caption for the Slideshow


### PR DESCRIPTION
This PR

* [x] removes `implements` operators

💁‍♂️ The [`Container`](https://github.com/facebook/facebook-instant-articles-sdk-php/blob/c0d9491ad7c44ae1e96fa7d5f7f54262b9f8186d/src/Facebook/InstantArticles/Elements/Container.php) interface implementation requirement is already announced at [`Audible`](https://github.com/facebook/facebook-instant-articles-sdk-php/blob/c0d9491ad7c44ae1e96fa7d5f7f54262b9f8186d/src/Facebook/InstantArticles/Elements/Audible.php#L28).