### PR TITLE
Fix: Remove return annotation

### DIFF
--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -98,7 +98,6 @@ class InstantArticle extends Element implements Container, InstantArticleInterfa
     /**
      * Private constructor. It must be used the Factory method
      * @see InstantArticle#create() For building objects
-     * @return InstantArticle object.
      */
     private function __construct()
     {


### PR DESCRIPTION
This PR

* [x] removes a `@return` annotation from the docblock of a constructor