### PR TITLE
Improved ImageRule

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/ImageRule.php
@@ -9,6 +9,8 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Image;
+use Facebook\InstantArticles\Elements\Caption;
+use Facebook\InstantArticles\Elements\Cite;
 use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
@@ -19,11 +21,14 @@ class ImageRule extends ConfigurationSelectorRule
     const PROPERTY_IMAGE_URL = 'image.url';
     const PROPERTY_LIKE = 'image.like';
     const PROPERTY_COMMENTS = 'image.comments';
+    const PROPERTY_CREDIT = 'image.credit';
+    const PROPERTY_CAPTION = 'image.caption';
 
     const ASPECT_FIT = 'aspect-fit';
     const ASPECT_FIT_ONLY = 'aspect-fit-only';
     const FULLSCREEN = 'fullscreen';
     const NON_INTERACTIVE = 'non-interactive';
+
 
     public function getContextClass()
     {
@@ -49,6 +54,8 @@ class ImageRule extends ConfigurationSelectorRule
                 self::PROPERTY_IMAGE_URL,
                 self::PROPERTY_LIKE,
                 self::PROPERTY_COMMENTS,
+                self::PROPERTY_CREDIT,
+                self::PROPERTY_CAPTION,
                 self::ASPECT_FIT,
                 self::ASPECT_FIT_ONLY,
                 self::FULLSCREEN,
@@ -115,6 +122,23 @@ class ImageRule extends ConfigurationSelectorRule
 
         if ($this->getProperty(self::PROPERTY_COMMENTS, $node)) {
             $image->enableComments();
+        }
+
+        $caption = null;
+        if ($this->getProperty(self::PROPERTY_CAPTION, $node)) {
+            $caption = Caption::create();
+            $transformer->transform($caption, $this->getProperty(self::PROPERTY_CAPTION, $node));
+        }
+        if ($this->getProperty(self::PROPERTY_CREDIT, $node)) {
+            if ($caption === null) {
+                $caption = Caption::create();
+            }
+            $credit = Cite::create();
+            $transformer->transform($credit, $this->getProperty(self::PROPERTY_CREDIT, $node));
+            $caption->withCredit($credit);
+        }
+        if ($caption !== null) {
+            $image->withCaption($caption);
         }
 
         $suppress_warnings = $transformer->suppress_warnings;

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
@@ -199,8 +199,9 @@
       </figure>
       <figure>
         <img src="http://example.com/image.jpg"/>
-        <figcaption>caption<cite>photo</cite></figcaption>
+        <figcaption>caption <i><b>bold italic</b></i> and <a href="http://domain.com">link</a><cite>photo credit <i><b>bold italic</b></i> and <a href="http://domain.com">link</a></cite></figcaption>
       </figure>
+      <figure><img src="http://example.com/credit-image.jpg"/></figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
@@ -197,6 +197,10 @@
         <img src="http://example.com/image.jpg"/>
         <figcaption>caption</figcaption>
       </figure>
+      <figure>
+        <img src="http://example.com/image.jpg"/>
+        <figcaption>caption<cite>photo</cite></figcaption>
+      </figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
@@ -604,7 +604,26 @@
     },
     {
         "class": "ImageRule",
-        "selector": ".image-with-credit",
+        "selector": ".image-with-credit-and-caption",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            },
+            "image.caption": {
+                "type": "element",
+                "selector": "p.caption"
+            },
+            "image.credit": {
+                "type": "element",
+                "selector": "p.credit"
+            }
+        }
+    },
+    {
+        "class": "ImageRule",
+        "selector": ".image-with-credit-only",
         "properties": {
             "image.url": {
                 "type": "string",
@@ -621,5 +640,6 @@
             }
         }
     }
+
   ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
@@ -601,6 +601,25 @@
                 ]
             }
         }
+    },
+    {
+        "class": "ImageRule",
+        "selector": ".image-with-credit",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            },
+            "image.caption": {
+                "type": "element",
+                "selector": "p.caption"
+            },
+            "image.credit": {
+                "type": "element",
+                "selector": "p.credit"
+            }
+        }
     }
   ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/custom.html
+++ b/tests/Facebook/InstantArticles/Transformer/custom.html
@@ -217,5 +217,12 @@
       <img class="wp-image-22553 size-large" src="http://example.com/image.jpg" alt="alt text" width="800" height="552" srcset="http://example.com/image-800.jpg 800w, http://example.com/image-400.jpg 400w, http://example.com/image-768.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" />
       <p class="wp-caption-text">caption</p>
     </div>
+    <div class="image-with-credit">
+        <a href="http://example.com/image.jpg">
+            <img src="http://example.com/image.jpg"/>
+        </a>
+        <p class="caption">caption</p>
+        <p class="credit">photo</p>
+    </div>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/custom.html
+++ b/tests/Facebook/InstantArticles/Transformer/custom.html
@@ -217,12 +217,18 @@
       <img class="wp-image-22553 size-large" src="http://example.com/image.jpg" alt="alt text" width="800" height="552" srcset="http://example.com/image-800.jpg 800w, http://example.com/image-400.jpg 400w, http://example.com/image-768.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" />
       <p class="wp-caption-text">caption</p>
     </div>
-    <div class="image-with-credit">
+    <div class="image-with-credit-and-caption">
         <a href="http://example.com/image.jpg">
             <img src="http://example.com/image.jpg"/>
         </a>
-        <p class="caption">caption</p>
-        <p class="credit">photo</p>
+        <p class="caption">caption <i><b>bold italic</b></i> and <a href="http://domain.com">link</a></p>
+        <p class="credit">photo credit <i><b>bold italic</b></i> and <a href="http://domain.com">link</a></p>
+    </div>
+    <div class="image-with-credit-only">
+        <a href="http://example.com/credit-image.jpg">
+            <img src="http://example.com/credit-image.jpg"/>
+        </a>
+        <p class="credit">photo ONLY credit <i><b>bold italic</b></i> and <a href="http://domain.com">link</a></p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This PR Improves the ImageRule to support common use cases of images with caption and credits.
Applies to HTML structure like:

``` 
<div class="image-container">
  <a href=…..>
    <img src="pic.jpg">
  </a>
  <p class="credits">by Mr. T</p>
  <p class="caption">Pain</p>
</div>
```