### PR TITLE
Fix slideshow image caption not displayed in case of empty caption title, but available credits

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SlideshowImageRule.php
@@ -66,17 +66,24 @@ class SlideshowImageRule extends ConfigurationSelectorRule
             );
         }
 
-        $caption = Caption::create();
+        $caption = null;
 
         $caption_title = $this->getProperty(self::PROPERTY_CAPTION_TITLE, $node);
         if ($caption_title) {
+            $caption = Caption::create();
             $caption->withTitle($caption_title);
-            $image->withCaption($caption);
         }
 
         $caption_credit = $this->getProperty(self::PROPERTY_CAPTION_CREDIT, $node);
         if ($caption_credit) {
+            if ($caption === null) {
+               $caption = Caption::create();
+            }
             $caption->withCredit($caption_credit);
+        }
+
+        if ($caption !== null) {
+            $image->withCaption($caption);
         }
 
         return $slideshow;


### PR DESCRIPTION
This PR changes the `SlideshowImageRule::apply()` method to display slideshow image caption in case of empty caption title, but available credits.

This ensures that the slideshow image caption is always displayed, when either the title or the credits have some output.
