### PR TITLE
HTML assert Equals for Unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Facebook\\InstantArticles\\": "tests/Facebook/InstantArticles/"
+            "Facebook\\": "tests/Facebook/"
         }
     },
     "scripts": {

--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -9,8 +9,9 @@
 namespace Facebook\InstantArticles\Elements;
 
 use Facebook\InstantArticles\Transformer\GeneratorTrait;
+use Facebook\Util\BaseHTMLTestCase;
 
-class AdTest extends \PHPUnit_Framework_TestCase
+class AdTest extends BaseHTMLTestCase
 {
     use GeneratorTrait;
 
@@ -38,7 +39,7 @@ class AdTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $ad->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasicWithHeightAndWidth()
@@ -55,7 +56,7 @@ class AdTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $ad->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasicWithDefaultEnabled()
@@ -73,7 +74,7 @@ class AdTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $ad->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderInlineWithHeightAndWidth()
@@ -97,6 +98,6 @@ class AdTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $ad->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class AnalyticsTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class AnalyticsTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -33,7 +35,7 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithHTML()
@@ -55,7 +57,7 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGoogleAnalytics()
@@ -84,6 +86,6 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/AudioTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AudioTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class AudioTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class AudioTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -32,7 +34,7 @@ class AudioTest extends \PHPUnit_Framework_TestCase
             '</audio>';
 
         $rendered = $audio->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTitle()
@@ -48,7 +50,7 @@ class AudioTest extends \PHPUnit_Framework_TestCase
             '</audio>';
 
         $rendered = $audio->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAutoplay()
@@ -64,7 +66,7 @@ class AudioTest extends \PHPUnit_Framework_TestCase
             '</audio>';
 
         $rendered = $audio->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithMuted()
@@ -80,7 +82,7 @@ class AudioTest extends \PHPUnit_Framework_TestCase
             '</audio>';
 
         $rendered = $audio->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTitleAndAutoplayMuted()
@@ -98,6 +100,6 @@ class AudioTest extends \PHPUnit_Framework_TestCase
             '</audio>';
 
         $rendered = $audio->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/AuthorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AuthorTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class AuthorTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class AuthorTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -36,7 +38,7 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
             '</address>';
 
         $rendered = $author->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderAuthorWithTwitter()
@@ -54,6 +56,6 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
             '</address>';
 
         $rendered = $author->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class BlockquoteTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class BlockquoteTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -32,7 +34,7 @@ class BlockquoteTest extends \PHPUnit_Framework_TestCase
             '</blockquote>';
 
         $rendered = $blockquote->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithBoldStrongItalicEm()
@@ -53,6 +55,6 @@ class BlockquoteTest extends \PHPUnit_Framework_TestCase
             '</blockquote>';
 
         $rendered = $blockquote->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class CaptionTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class CaptionTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -32,7 +34,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithSubTitle()
@@ -49,7 +51,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCredit()
@@ -66,7 +68,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPosition()
@@ -82,7 +84,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLargeFontSize()
@@ -98,7 +100,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithSmallFontSize()
@@ -114,7 +116,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTextAlignment()
@@ -130,7 +132,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithVerticalAlignment()
@@ -146,7 +148,7 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
           '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAllFormating()
@@ -165,6 +167,6 @@ class CaptionTest extends \PHPUnit_Framework_TestCase
             '</figcaption>';
 
         $rendered = $caption->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class CiteTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class CiteTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -32,7 +34,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPosition()
@@ -48,7 +50,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTextAlign()
@@ -64,7 +66,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithVerticalAlign()
@@ -80,7 +82,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
           '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPositionAndAlignment()
@@ -98,7 +100,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithUnescapedHTML()
@@ -116,7 +118,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFormattedText()
@@ -137,7 +139,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLink()
@@ -158,7 +160,7 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithNestedFormattedText()
@@ -178,6 +180,6 @@ class CiteTest extends \PHPUnit_Framework_TestCase
             '</cite>';
 
         $rendered = $cite->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class FooterTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class FooterTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -34,7 +36,7 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithParagraphCredits()
@@ -59,7 +61,7 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithParagraphCreditsAppend()
@@ -86,7 +88,7 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCopyright()
@@ -103,7 +105,7 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCopyrightSmallElement()
@@ -128,7 +130,7 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithRelatedArticles()
@@ -156,6 +158,6 @@ class FooterTest extends \PHPUnit_Framework_TestCase
             '</footer>';
 
         $rendered = $footer->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
+++ b/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class GeoTagTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class GeoTagTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -46,6 +48,6 @@ JSON;
             '</script>';
 
         $rendered = $geo_tag->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class H1Test extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class H1Test extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -32,7 +34,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPosition()
@@ -48,7 +50,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTextAlign()
@@ -64,7 +66,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPositionAndAlignment()
@@ -81,7 +83,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithUnescapedHTML()
@@ -99,7 +101,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFormattedText()
@@ -120,7 +122,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLink()
@@ -141,7 +143,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithNestedFormattedText()
@@ -161,7 +163,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
             '</h1>';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptySpace()
@@ -173,7 +175,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptyNBSP()
@@ -185,7 +187,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptySpaces()
@@ -197,7 +199,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWhiteSpaceChars()
@@ -209,7 +211,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptyFormatted()
@@ -221,7 +223,7 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h1->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testGetPlainText()
@@ -239,6 +241,6 @@ class H1Test extends \PHPUnit_Framework_TestCase
         $expected = 'Some text to be within a paragraph for testing.';
 
         $rendered = $h1->getPlainText();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class H2Test extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class H2Test extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -32,7 +34,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPosition()
@@ -48,7 +50,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTextAlign()
@@ -64,7 +66,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPositionAndAlignment()
@@ -81,7 +83,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithUnescapedHTML()
@@ -99,7 +101,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFormattedText()
@@ -120,7 +122,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLink()
@@ -141,7 +143,7 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithNestedFormattedText()
@@ -161,6 +163,6 @@ class H2Test extends \PHPUnit_Framework_TestCase
             '</h2>';
 
         $rendered = $h2->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/H3Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H3Test.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class H3Test extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class H3Test extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -32,7 +34,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPosition()
@@ -48,7 +50,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTextAlign()
@@ -64,7 +66,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPositionAndAlignment()
@@ -81,7 +83,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithUnescapedHTML()
@@ -99,7 +101,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFormattedText()
@@ -120,7 +122,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLink()
@@ -141,7 +143,7 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithNestedFormattedText()
@@ -161,6 +163,6 @@ class H3Test extends \PHPUnit_Framework_TestCase
             '</h3>';
 
         $rendered = $h3->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class HeaderTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class HeaderTest extends BaseHTMLTestCase
 {
 
     public function testHeaderEmpty()
@@ -16,7 +18,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
         $header = Header::create();
         $expected = '';
         $rendered = $header->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testCompleteHeader()
@@ -123,7 +125,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testHeaderWithSingleDefaultAd()
@@ -148,7 +150,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testHeaderWithTitles()
@@ -177,7 +179,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testHeaderWithTitlesFormatted()
@@ -209,7 +211,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testHeaderWithSlideshow()
@@ -258,7 +260,7 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testHeaderWithSponsor()
@@ -299,6 +301,6 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
 
         $rendered = $header->render();
 
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class ImageTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class ImageTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -32,7 +34,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCaption()
@@ -52,7 +54,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAttributionCaption()
@@ -77,7 +79,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLike()
@@ -98,7 +100,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithComments()
@@ -119,7 +121,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLikeAndComments()
@@ -141,7 +143,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFullscreen()
@@ -157,7 +159,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGeotag()
@@ -192,7 +194,7 @@ JSON;
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAudio()
@@ -221,6 +223,6 @@ JSON;
             '</figure>';
 
         $rendered = $image->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class InstantArticleTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class InstantArticleTest extends BaseHTMLTestCase
 {
     /**
      * @var InstantArticle
@@ -206,7 +208,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
             '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $this->article->render());
+        $this->assertEqualsHtml($expected, $this->article->render());
     }
 
     public function testRenderWithAds()
@@ -279,7 +281,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
 
         $this->article->getHeader()->addAd(Ad::create()->withSource('http://foo.com'));
 
-        $this->assertEquals($expected, $this->article->render());
+        $this->assertEqualsHtml($expected, $this->article->render());
     }
 
     public function testRenderWithoutAds()
@@ -311,7 +313,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testInstantArticleAlmostEmpty()
@@ -406,7 +408,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
             '</html>';
 
         $result = $article->render();
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testIsValid()
@@ -503,7 +505,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testGetFirstParagraph()
@@ -540,7 +542,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
         $result = $article->getFirstParagraph()->render();
         $expected = '<p>Yes, peace is good for everybody!<br/> Man kind.</p>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testGetEmptyFirstParagraph()
@@ -550,7 +552,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
         $result = $article->getFirstParagraph()->render();
         $expected = '';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testDeleteChildren()
@@ -612,7 +614,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testDeleteOnlyChild()
@@ -669,7 +671,7 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 
     public function testReplaceChildren()
@@ -736,6 +738,6 @@ class InstantArticleTest extends \PHPUnit_Framework_TestCase
                 '</body>'.
             '</html>';
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -10,8 +10,9 @@ namespace Facebook\InstantArticles;
 
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Interactive;
+use Facebook\Util\BaseHTMLTestCase;
 
-class InteractiveTest extends \PHPUnit_Framework_TestCase
+class InteractiveTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -20,7 +21,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertFalse($interactive->isValid());
     }
 
@@ -38,7 +39,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasicWithCaption()
@@ -60,7 +61,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $social_embed->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasicWithOnlyHeight()
@@ -73,7 +74,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertFalse($interactive->isValid());
     }
 
@@ -87,7 +88,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertFalse($interactive->isValid());
     }
 
@@ -105,7 +106,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
           '</figure>';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasicWithOnlyColumnWidth()
@@ -118,7 +119,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertFalse($interactive->isValid());
     }
 
@@ -132,7 +133,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertFalse($interactive->isValid());
     }
 
@@ -158,7 +159,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderInline()
@@ -181,7 +182,7 @@ class InteractiveTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $interactive->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
         $this->assertTrue($interactive->isValid());
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class ListElementTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class ListElementTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -18,7 +20,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderListItemsAllEmpty()
@@ -33,7 +35,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderOrdered()
@@ -52,7 +54,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
             '</ol>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderOrderedWithAllItems()
@@ -69,7 +71,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
             '</ol>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderUnordered()
@@ -88,7 +90,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderUnorderedWithAllItems()
@@ -105,7 +107,7 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithSingleContainerUnordered()
@@ -124,6 +126,6 @@ class ListElementTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class MapTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class MapTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class MapTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $map->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGeotag()
@@ -50,7 +52,7 @@ JSON;
         '</figure>';
 
         $rendered = $map->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGeotagAndCaption()
@@ -93,6 +95,6 @@ JSON;
         '</figure>';
 
         $rendered = $map->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class ParagraphTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class ParagraphTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithUnescapedHTML()
@@ -35,7 +37,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
             '</p>';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFormattedText()
@@ -58,7 +60,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
             '</p>';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLineBreak()
@@ -76,7 +78,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
             '</p>';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLink()
@@ -97,7 +99,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
             '</p>';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptyText()
@@ -109,7 +111,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptyNBSP()
@@ -121,7 +123,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptySpaces()
@@ -133,7 +135,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWhiteSpaceChars()
@@ -145,7 +147,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderEmptyFormatted()
@@ -157,7 +159,7 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithNestedFormattedText()
@@ -178,6 +180,6 @@ class ParagraphTest extends \PHPUnit_Framework_TestCase
             '</p>';
 
         $rendered = $paragraph->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class PullquoteTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class PullquoteTest extends BaseHTMLTestCase
 {
     public function testRenderBasic()
     {
@@ -18,7 +20,7 @@ class PullquoteTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithBoldStrongItalicEm()
@@ -39,7 +41,7 @@ class PullquoteTest extends \PHPUnit_Framework_TestCase
             '</aside>';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAttribution()
@@ -62,6 +64,6 @@ class PullquoteTest extends \PHPUnit_Framework_TestCase
             '</aside>';
 
         $rendered = $analytics->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
+++ b/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class RelatedArticlesTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -18,7 +20,7 @@ class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $element->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -37,7 +39,7 @@ class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $element->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithTitle()
@@ -57,6 +59,6 @@ class RelatedArticlesTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $element->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class SlideshowTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class SlideshowTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class SlideshowTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -42,7 +44,7 @@ class SlideshowTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLikeAndComments()
@@ -80,7 +82,7 @@ class SlideshowTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCaption()
@@ -110,7 +112,7 @@ class SlideshowTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGeotag()
@@ -155,7 +157,7 @@ JSON;
             '</figure>';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAudio()
@@ -194,6 +196,6 @@ JSON;
             '</figure>';
 
         $rendered = $slideshow->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/SponsorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SponsorTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class SponsorTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class SponsorTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -18,7 +20,7 @@ class SponsorTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithSponsor()
@@ -35,6 +37,6 @@ class SponsorTest extends \PHPUnit_Framework_TestCase
             '</ul>';
 
         $rendered = $list->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/TimeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/TimeTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class TimeTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class TimeTest extends BaseHTMLTestCase
 {
     private $timeDate;
 
@@ -28,7 +30,7 @@ class TimeTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $time->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -43,7 +45,7 @@ class TimeTest extends \PHPUnit_Framework_TestCase
             '</time>';
 
         $rendered = $time->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderModified()
@@ -58,6 +60,6 @@ class TimeTest extends \PHPUnit_Framework_TestCase
             '</time>';
 
         $rendered = $time->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-class VideoTest extends \PHPUnit_Framework_TestCase
+use Facebook\Util\BaseHTMLTestCase;
+
+class VideoTest extends BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {
@@ -17,7 +19,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $expected = '';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderBasic()
@@ -34,7 +36,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithAttribution()
@@ -55,7 +57,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithPresentation()
@@ -73,7 +75,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithControls()
@@ -91,7 +93,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithoutAutoplay()
@@ -109,7 +111,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithCaption()
@@ -131,7 +133,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLike()
@@ -154,7 +156,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithComments()
@@ -177,7 +179,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithLikeAndComments()
@@ -201,7 +203,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithGeotag()
@@ -238,7 +240,7 @@ JSON;
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 
     public function testRenderWithFeedCover()
@@ -256,6 +258,6 @@ JSON;
             '</figure>';
 
         $rendered = $video->render();
-        $this->assertEquals($expected, $rendered);
+        $this->assertEqualsHtml($expected, $rendered);
     }
 }

--- a/tests/Facebook/InstantArticles/Parser/ParserTest.php
+++ b/tests/Facebook/InstantArticles/Parser/ParserTest.php
@@ -9,29 +9,10 @@
 namespace Facebook\InstantArticles\Parser;
 
 use Facebook\InstantArticles\Transformer\Transformer;
+use Facebook\Util\BaseHTMLTestCase;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends BaseHTMLTestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testSelfParse()
     {
         $html_file = file_get_contents(__DIR__ . '/instant-article-example.html');
@@ -47,7 +28,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
 
-        $this->assertEquals($html_file, $result);
+        $this->assertEqualsHtml($html_file, $result);
     }
 
     public function testSelfParseString()
@@ -60,7 +41,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
 
-        $this->assertEquals($html_file, $result);
+        $this->assertEqualsHtml($html_file, $result);
     }
 
     public function testSelfParseStringNoTimezone()
@@ -74,7 +55,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
 
-        $this->assertEquals($html_file_standard_timezone, $result);
+        $this->assertEqualsHtml($html_file_standard_timezone, $result);
     }
 
     public function testSelfParseStringNoTimezoneWithDefaultNYC()
@@ -91,7 +72,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
 
-        $this->assertEquals($html_file_standard_timezone, $result);
+        $this->assertEqualsHtml($html_file_standard_timezone, $result);
     }
 
     public function testSelfParseAdPlacementOptions()
@@ -110,6 +91,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $result = $instant_article->render('', true)."\n";
 
-        $this->assertEquals($html_file, $result);
+        $this->assertEqualsHtml($html_file, $result);
     }
 }

--- a/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
@@ -13,29 +13,10 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Author;
+use Facebook\Util\BaseHTMLTestCase;
 
-class CustomHTMLTransformerTest extends \PHPUnit_Framework_TestCase
+class CustomHTMLTransformerTest extends BaseHTMLTestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testTransformerCustomHTML()
     {
         $json_file = file_get_contents(__DIR__ . '/custom-html-rules.json');
@@ -71,7 +52,7 @@ class CustomHTMLTransformerTest extends \PHPUnit_Framework_TestCase
         $result = $instant_article->render('', true)."\n";
         $expected = file_get_contents(__DIR__ . '/custom-html-ia.xml');
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
         // there must be 3 warnings related to <img> inside <li> that is not supported by IA
         $this->assertCount(3, $transformer->getWarnings());
     }

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -9,29 +9,10 @@
 namespace Facebook\InstantArticles\Transformer;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\Util\BaseHTMLTestCase;
 
-class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
+class SimpleTransformerTest extends BaseHTMLTestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testSelfTransformerContent()
     {
         $json_file = file_get_contents(__DIR__ . '/simple-rules.json');
@@ -55,6 +36,6 @@ class SimpleTransformerTest extends \PHPUnit_Framework_TestCase
 
         //var_dump($result);
         // print_r($warnings);
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 }

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -9,8 +9,9 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Parser\Parser;
+use Facebook\Util\BaseHTMLTestCase;
 
-class AuthorRuleTest extends \PHPUnit_Framework_TestCase
+class AuthorRuleTest extends BaseHTMLTestCase
 {
     public function testCreateFromProperties()
     {
@@ -70,7 +71,7 @@ class AuthorRuleTest extends \PHPUnit_Framework_TestCase
         $instantArticle = $parser->parse($html);
         $author = $instantArticle->getHeader()->getAuthors()[0];
 
-        $this->assertEquals($expectedName, $author->getName());
+        $this->assertEqualsHtml($expectedName, $author->getName());
     }
 
     public function testExpectedNameWithoutLink()
@@ -87,6 +88,6 @@ class AuthorRuleTest extends \PHPUnit_Framework_TestCase
         $instantArticle = $parser->parse($html);
         $author = $instantArticle->getHeader()->getAuthors()[0];
 
-        $this->assertEquals($expectedName, $author->getName());
+        $this->assertEqualsHtml($expectedName, $author->getName());
     }
 }

--- a/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
@@ -10,29 +10,10 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\Util\BaseHTMLTestCase;
 
-class PullquoteRuleTest extends \PHPUnit_Framework_TestCase
+class PullquoteRuleTest extends BaseHTMLTestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testTransformPullquote()
     {
         $transformer_rules = <<<'JSON'
@@ -95,6 +76,6 @@ JSON;
         $pullquote = $instant_article->getChildren()[0];
         $result = $pullquote->render('', true)."\n";
 
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsHtml($expected, $result);
     }
 }

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -16,29 +16,10 @@ use Facebook\InstantArticles\Transformer\Rules\H1Rule;
 use Facebook\InstantArticles\Transformer\Rules\ItalicRule;
 use Facebook\InstantArticles\Transformer\Rules\ParagraphRule;
 use Facebook\InstantArticles\Transformer\Rules\TextNodeRule;
+use Facebook\Util\BaseHTMLTestCase;
 
-class TransformerTest extends \PHPUnit_Framework_TestCase
+class TransformerTest extends BaseHTMLTestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testTransformString()
     {
         $json_file = file_get_contents('src/Facebook/InstantArticles/Parser/instant-articles-rules.json');
@@ -51,7 +32,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $header = Header::create();
         $transformer->transformString($header, $title_html_string);
 
-        $this->assertEquals('<h1>Title String</h1>', $header->getTitle()->render());
+        $this->assertEqualsHtml('<h1>Title String</h1>', $header->getTitle()->render());
     }
 
     public function testTransformStringWithMultibyteUTF8Content()
@@ -66,7 +47,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $header = Header::create();
         $transformer->transformString($header, $title_html_string);
 
-        $this->assertEquals('<h1>Test:あÖÄÜöäü</h1>', $header->getTitle()->render());
+        $this->assertEqualsHtml('<h1>Test:あÖÄÜöäü</h1>', $header->getTitle()->render());
     }
 
     public function testTransformStringWithMultibyteNonUTF8Content()
@@ -81,7 +62,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $header = Header::create();
         $transformer->transformString($header, $title_html_string, 'euc-jp');
 
-        $this->assertEquals('<h1>Test:あÖÄÜöäü</h1>', $header->getTitle()->render());
+        $this->assertEqualsHtml('<h1>Test:あÖÄÜöäü</h1>', $header->getTitle()->render());
     }
 
     public function testSelfTransformerContent()
@@ -106,7 +87,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
 
         //var_dump($result);
         // print_r($warnings);
-        $this->assertEquals($html_file, $result);
+        $this->assertEqualsHtml($html_file, $result);
     }
 
     public function testSelfTransformerMultibyteContent()
@@ -127,7 +108,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
 
         // some fragments are written as html entities even after transformed so
         // noralize all strings to html entities and compare them.
-        $this->assertEquals(
+        $this->assertEqualsHtml(
             mb_convert_encoding($html_file, 'HTML-ENTITIES', 'utf-8'),
             mb_convert_encoding($result, 'HTML-ENTITIES', 'utf-8')
         );
@@ -151,7 +132,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
 
         // some fragments are written as html entities even after transformed so
         // noralize all strings to html entities and compare them.
-        $this->assertEquals(
+        $this->assertEqualsHtml(
             mb_convert_encoding($html_file, 'HTML-ENTITIES', 'euc-jp'),
             mb_convert_encoding($result, 'HTML-ENTITIES', 'utf-8')
         );

--- a/tests/Facebook/Util/BaseHTMLTestCase.php
+++ b/tests/Facebook/Util/BaseHTMLTestCase.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\Util;
+
+class BaseHTMLTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        \Logger::configure(
+            [
+                'rootLogger' => [
+                    'appenders' => ['facebook-instantarticles-transformer']
+                ],
+                'appenders' => [
+                    'facebook-instantarticles-transformer' => [
+                        'class' => 'LoggerAppenderConsole',
+                        'threshold' => 'INFO',
+                        'layout' => [
+                            'class' => 'LoggerLayoutSimple'
+                        ]
+                    ]
+                ]
+            ]
+        );
+    }
+
+    protected function assertEqualsHtml($expected, $actual)
+    {
+        $from = ['/\>[^\S ]+/s', '/[^\S ]+\</s', '/(\s)+/s', '/> </s'];
+        $to = ['>', '<', '\\1', '><'];
+        $this->assertEquals(
+            preg_replace($from, $to, $expected),
+            preg_replace($from, $to, $actual)
+        );
+    }
+}


### PR DESCRIPTION
* [x] Created base class BaseHTMLTestCase
* [x] Changed assertEquals calls to assertEqualsHtml
* [x] Changed test cases as needed to extend BaseHTMLTestCase

Fixes Test cases broken because of spacing/formatting issues.
