### PR TITLE
Making tests tz UTC by default

### DIFF
--- a/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
@@ -19,6 +19,8 @@ class CustomHTMLTransformerTest extends BaseHTMLTestCase
 {
     public function testTransformerCustomHTML()
     {
+        date_default_timezone_set('UTC');
+
         $json_file = file_get_contents(__DIR__ . '/custom-html-rules.json');
 
         $instant_article = InstantArticle::create();

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
@@ -15,6 +15,8 @@ class GlobalTransformerTest extends BaseHtmlTestCase
 {
     public function testSelfTransformerContent()
     {
+        date_default_timezone_set('UTC');
+
         $json_file = file_get_contents(__DIR__ . '/global-rules.json');
 
         $instant_article = InstantArticle::create();


### PR DESCRIPTION
This PR

* Fixes some tests that were failing on some timezones. Made them UTC by default.
