### PR TITLE
using full path for BaseHTMLTestCase (for www compatibility)

### DIFF
--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class AdTest extends BaseHTMLTestCase
+class AdTest extends \Facebook\Util\BaseHTMLTestCase
 {
 
     public function testRenderEmpty()

--- a/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AnalyticsTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class AnalyticsTest extends BaseHTMLTestCase
+class AnalyticsTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/AudioTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AudioTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class AudioTest extends BaseHTMLTestCase
+class AudioTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/AuthorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AuthorTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class AuthorTest extends BaseHTMLTestCase
+class AuthorTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/BlockquoteTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class BlockquoteTest extends BaseHTMLTestCase
+class BlockquoteTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/CaptionTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CaptionTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class CaptionTest extends BaseHTMLTestCase
+class CaptionTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/CiteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/CiteTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class CiteTest extends BaseHTMLTestCase
+class CiteTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/FooterTest.php
+++ b/tests/Facebook/InstantArticles/Elements/FooterTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class FooterTest extends BaseHTMLTestCase
+class FooterTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
+++ b/tests/Facebook/InstantArticles/Elements/GeoTagTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class GeoTagTest extends BaseHTMLTestCase
+class GeoTagTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/H1Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H1Test.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class H1Test extends BaseHTMLTestCase
+class H1Test extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/H2Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H2Test.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class H2Test extends BaseHTMLTestCase
+class H2Test extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/H3Test.php
+++ b/tests/Facebook/InstantArticles/Elements/H3Test.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class H3Test extends BaseHTMLTestCase
+class H3Test extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/HeaderTest.php
+++ b/tests/Facebook/InstantArticles/Elements/HeaderTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class HeaderTest extends BaseHTMLTestCase
+class HeaderTest extends \Facebook\Util\BaseHTMLTestCase
 {
 
     public function testHeaderEmpty()

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class ImageTest extends BaseHTMLTestCase
+class ImageTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class InstantArticleTest extends BaseHTMLTestCase
+class InstantArticleTest extends \Facebook\Util\BaseHTMLTestCase
 {
     /**
      * @var InstantArticle

--- a/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InteractiveTest.php
@@ -10,9 +10,8 @@ namespace Facebook\InstantArticles;
 
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Interactive;
-use Facebook\Util\BaseHTMLTestCase;
 
-class InteractiveTest extends BaseHTMLTestCase
+class InteractiveTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/ListElementTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ListElementTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class ListElementTest extends BaseHTMLTestCase
+class ListElementTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/MapTest.php
+++ b/tests/Facebook/InstantArticles/Elements/MapTest.php
@@ -9,9 +9,8 @@
 namespace Facebook\InstantArticles\Elements;
 
 use Facebook\InstantArticles\Elements\Map as Map;
-use Facebook\Util\BaseHTMLTestCase;
 
-class MapTest extends BaseHTMLTestCase
+class MapTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ParagraphTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class ParagraphTest extends BaseHTMLTestCase
+class ParagraphTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
+++ b/tests/Facebook/InstantArticles/Elements/PullquoteTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class PullquoteTest extends BaseHTMLTestCase
+class PullquoteTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderBasic()
     {

--- a/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
+++ b/tests/Facebook/InstantArticles/Elements/RelatedArticlesTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class RelatedArticlesTest extends BaseHTMLTestCase
+class RelatedArticlesTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class SlideshowTest extends BaseHTMLTestCase
+class SlideshowTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/SponsorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SponsorTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class SponsorTest extends BaseHTMLTestCase
+class SponsorTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Elements/TimeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/TimeTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class TimeTest extends BaseHTMLTestCase
+class TimeTest extends \Facebook\Util\BaseHTMLTestCase
 {
     private $timeDate;
 

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -8,9 +8,7 @@
  */
 namespace Facebook\InstantArticles\Elements;
 
-use Facebook\Util\BaseHTMLTestCase;
-
-class VideoTest extends BaseHTMLTestCase
+class VideoTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testRenderEmpty()
     {

--- a/tests/Facebook/InstantArticles/Parser/ParserTest.php
+++ b/tests/Facebook/InstantArticles/Parser/ParserTest.php
@@ -9,9 +9,8 @@
 namespace Facebook\InstantArticles\Parser;
 
 use Facebook\InstantArticles\Transformer\Transformer;
-use Facebook\Util\BaseHTMLTestCase;
 
-class ParserTest extends BaseHTMLTestCase
+class ParserTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testSelfParse()
     {

--- a/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/CustomHTMLTransformerTest.php
@@ -13,9 +13,8 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Author;
-use Facebook\Util\BaseHTMLTestCase;
 
-class CustomHTMLTransformerTest extends BaseHTMLTestCase
+class CustomHTMLTransformerTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testTransformerCustomHTML()
     {

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -9,9 +9,8 @@
 namespace Facebook\InstantArticles\Transformer;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\Util\BaseHTMLTestCase;
 
-class SimpleTransformerTest extends BaseHTMLTestCase
+class SimpleTransformerTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testSelfTransformerContent()
     {

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
@@ -10,9 +10,8 @@ namespace Facebook\InstantArticles\Transformer\GlobalHtml;
 
 use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\Util\BaseHTMLTestCase;
 
-class GlobalTransformerTest extends BaseHTMLTestCase
+class GlobalTransformerTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testSelfTransformerContent()
     {

--- a/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/AuthorRuleTest.php
@@ -9,9 +9,8 @@
 namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Parser\Parser;
-use Facebook\Util\BaseHTMLTestCase;
 
-class AuthorRuleTest extends BaseHTMLTestCase
+class AuthorRuleTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testCreateFromProperties()
     {

--- a/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/PullquoteRuleTest.php
@@ -10,9 +10,8 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\Util\BaseHTMLTestCase;
 
-class PullquoteRuleTest extends BaseHTMLTestCase
+class PullquoteRuleTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testTransformPullquote()
     {

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -16,9 +16,8 @@ use Facebook\InstantArticles\Transformer\Rules\H1Rule;
 use Facebook\InstantArticles\Transformer\Rules\ItalicRule;
 use Facebook\InstantArticles\Transformer\Rules\ParagraphRule;
 use Facebook\InstantArticles\Transformer\Rules\TextNodeRule;
-use Facebook\Util\BaseHTMLTestCase;
 
-class TransformerTest extends BaseHTMLTestCase
+class TransformerTest extends \Facebook\Util\BaseHTMLTestCase
 {
     public function testTransformString()
     {


### PR DESCRIPTION
This PR

* Changes tests to extend BaseHTMLTestCase with full path so it doesn't have HHVM lints in www.