### PR TITLE
BaseHTMLTestCase abstract class

### DIFF
--- a/tests/Facebook/Util/BaseHTMLTestCase.php
+++ b/tests/Facebook/Util/BaseHTMLTestCase.php
@@ -8,7 +8,7 @@
  */
 namespace Facebook\Util;
 
-class BaseHTMLTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseHTMLTestCase extends \PHPUnit_Framework_TestCase
 {
     protected function assertEqualsHtml($expected, $actual)
     {


### PR DESCRIPTION
This way this class won't be confused as test case for few environments

This PR
* [x] Makes class BaseHTMLTestCase abstract
