### PR TITLE
convert &amp;{entitityname}; in output to &{entityname};

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -59,7 +59,9 @@ abstract class Element
         $rendered = str_replace('></source>', '/>', $rendered);
         $rendered = str_replace('></track>', '/>', $rendered);
         $rendered = str_replace('></wbr>', '/>', $rendered);
-
+        // createTextNode converts the & of html entities into &amp; - convert it back
+        $rendered = preg_replace('/&amp;([^(\s|;)]*;)/', '&$1', $rendered);
+        
         return $rendered;
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -11,6 +11,7 @@ namespace Facebook\InstantArticles\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
 
 use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\Author;
 use Facebook\InstantArticles\Transformer\Rules\BoldRule;
 use Facebook\InstantArticles\Transformer\Rules\H1Rule;
 use Facebook\InstantArticles\Transformer\Rules\ItalicRule;
@@ -33,6 +34,13 @@ class TransformerTest extends BaseHTMLTestCase
         $transformer->transformString($header, $title_html_string);
 
         $this->assertEqualsHtml('<h1>Title String</h1>', $header->getTitle()->render());
+    }
+
+    public function testDontTransformHTMLEntitiesTwice()
+    {
+        $author = Author::create()->withName("Test &amp; Test");
+        $rendered = ($author)->render('', true);
+        $this->assertEqualsHtml("<address><a>Test &amp; Test</a></address>", $rendered);
     }
 
     public function testTransformStringWithMultibyteUTF8Content()

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -39,7 +39,7 @@ class TransformerTest extends BaseHTMLTestCase
     public function testDontTransformHTMLEntitiesTwice()
     {
         $author = Author::create()->withName("Test &amp; Test");
-        $rendered = ($author)->render('', true);
+        $rendered = $author->render('', true);
         $this->assertEqualsHtml("<address><a>Test &amp; Test</a></address>", $rendered);
     }
 


### PR DESCRIPTION
All classes extending Element make use of createTextNode which converts symbols
to their respective HTML entities e.g. `&` -> `&amp;`

The inputs are not sanitized and therefore if they contain entities the & part
will be converted to &amp; e.g. `&quot;` -> `&amp;quot;`

This commit adds a test to prove this and fixes the problem by converting the
render output back.

Fixes https://github.com/Automattic/facebook-instant-articles-wp/issues/693
