### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6.0",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.36",
         "squizlabs/php_codesniffer": "^2.6.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8841c13d6e972dcf95be310e7057845a",
+    "content-hash": "22ad829cbb45885884e2cb7e6b80c620",
     "packages": [
         {
             "name": "apache/log4php",
@@ -608,16 +608,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.29",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f19d481b468b76a7fb55eb2b772ed487e484891e",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -676,7 +676,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-20T10:35:28+00:00"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/tests/Facebook/InstantArticles/Client/ClientExceptionTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientExceptionTest.php
@@ -2,7 +2,9 @@
 
 namespace Facebook\InstantArticles\Client;
 
-class ClientExceptionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClientExceptionTest extends TestCase
 {
     public function testExtendsException()
     {

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -11,8 +11,9 @@ namespace Facebook\InstantArticles\Client;
 use Facebook\Facebook;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     private $client;
     private $article;

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -9,8 +9,9 @@
 namespace Facebook\InstantArticles\Client;
 
 use Facebook\Facebook;
+use PHPUnit\Framework\TestCase;
 
-class HelperTest extends \PHPUnit_Framework_TestCase
+class HelperTest extends TestCase
 {
     private $helper;
     private $facebook;

--- a/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
@@ -16,12 +16,13 @@ use Facebook\InstantArticles\Elements\Footer;
 use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\SlideShow;
 use Facebook\InstantArticles\Elements\InstantArticle;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test unit against InstantArticleValidator
  * @see InstantArticleValidator
  */
-class InstantArticleValidatorTest extends \PHPUnit_Framework_TestCase
+class InstantArticleValidatorTest extends TestCase
 {
     public function testInstantArticle()
     {

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -13,11 +13,12 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\AnimatedGIF;
+use PHPUnit\Framework\TestCase;
 
 /**
  *
  */
-class TypeTest extends \PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
 
     /*

--- a/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\InstantArticles\Transformer\Rules;
 
-class RuleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class RuleTest extends TestCase
 {
     public function testCreateFromPropertiesThrowsException()
     {

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\Transformer;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
-
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Transformer\Rules\BoldRule;
 use Facebook\InstantArticles\Transformer\Rules\H1Rule;

--- a/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Warnings/InvalidSelectorTest.php
@@ -10,8 +10,9 @@ namespace Facebook\InstantArticles\Transformer\Warnings;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Transformer\Rules\SocialEmbedRule;
+use PHPUnit\Framework\TestCase;
 
-class InvalidSelectorTest extends \PHPUnit_Framework_TestCase
+class InvalidSelectorTest extends TestCase
 {
     public function testInvalidSelectorToString()
     {

--- a/tests/Facebook/Util/BaseHTMLTestCase.php
+++ b/tests/Facebook/Util/BaseHTMLTestCase.php
@@ -8,7 +8,9 @@
  */
 namespace Facebook\Util;
 
-abstract class BaseHTMLTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseHTMLTestCase extends TestCase
 {
     protected function setUp()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to update to PHPUnit [`PHPUnit 4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) for compatibility.