### PR TITLE
Adds property to global rules for header Image

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
@@ -140,18 +140,18 @@ class GlobalRule extends ConfigurationSelectorRule
         }
 
         // Treats Header Image
-        $articleHeaderImage = $this->getProperty(self::PROPERTY_GLOBAL_HEADER_IMAGE, $node);
-        if ($articleHeaderImage) {
-            $header->withCover($articleHeaderImage);
+        $articleHeaderImageURL = $this->getProperty(self::PROPERTY_GLOBAL_HEADER_IMAGE, $node);
+        if ($articleHeaderImageURL) {
+            $header->withCover(Image::create()->withURL($articleHeaderImageURL));
         } else {
             $transformer->addWarning(
                 new InvalidSelector(
                 self::PROPERTY_GLOBAL_HEADER_IMAGE,
                 $instantArticle,
                 $node,
-                $this  
+                $this
               )
-            )
+            );
         }
 
         $body = $this->getProperty(self::PROPERTY_GLOBAL_BODY, $node);

--- a/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
@@ -143,15 +143,6 @@ class GlobalRule extends ConfigurationSelectorRule
         $articleHeaderImageURL = $this->getProperty(self::PROPERTY_GLOBAL_HEADER_IMAGE, $node);
         if ($articleHeaderImageURL) {
             $header->withCover(Image::create()->withURL($articleHeaderImageURL));
-        } else {
-            $transformer->addWarning(
-                new InvalidSelector(
-                    self::PROPERTY_GLOBAL_HEADER_IMAGE,
-                    $instantArticle,
-                    $node,
-                    $this
-                )
-            );
         }
 
         $body = $this->getProperty(self::PROPERTY_GLOBAL_BODY, $node);

--- a/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
@@ -146,11 +146,11 @@ class GlobalRule extends ConfigurationSelectorRule
         } else {
             $transformer->addWarning(
                 new InvalidSelector(
-                self::PROPERTY_GLOBAL_HEADER_IMAGE,
-                $instantArticle,
-                $node,
-                $this
-              )
+                    self::PROPERTY_GLOBAL_HEADER_IMAGE,
+                    $instantArticle,
+                    $node,
+                    $this
+                )
             );
         }
 

--- a/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/GlobalRule.php
@@ -13,6 +13,7 @@ use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Author;
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\H1;
+use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class GlobalRule extends ConfigurationSelectorRule
@@ -25,6 +26,7 @@ class GlobalRule extends ConfigurationSelectorRule
     const PROPERTY_GLOBAL_TITLE = 'article.title';
     const PROPERTY_TIME_PUBLISHED = 'article.publish';
     const PROPERTY_GLOBAL_BODY = 'article.body';
+    const PROPERTY_GLOBAL_HEADER_IMAGE = 'image.url';
 
     public function getContextClass()
     {
@@ -51,7 +53,8 @@ class GlobalRule extends ConfigurationSelectorRule
                 self::PROPERTY_GLOBAL_CANONICAL_URL,
                 self::PROPERTY_GLOBAL_TITLE,
                 self::PROPERTY_TIME_PUBLISHED,
-                self::PROPERTY_GLOBAL_BODY
+                self::PROPERTY_GLOBAL_BODY,
+                self::PROPERTY_GLOBAL_HEADER_IMAGE
             ],
             $properties
         );
@@ -134,6 +137,21 @@ class GlobalRule extends ConfigurationSelectorRule
         $timePublished = $this->getProperty(self::PROPERTY_TIME_PUBLISHED, $node);
         if ($timePublished) {
             $header->withTime(Time::create(Time::PUBLISHED)->withDatetime($timePublished));
+        }
+
+        // Treats Header Image
+        $articleHeaderImage = $this->getProperty(self::PROPERTY_GLOBAL_HEADER_IMAGE, $node);
+        if ($articleHeaderImage) {
+            $header->withCover($articleHeaderImage);
+        } else {
+            $transformer->addWarning(
+                new InvalidSelector(
+                self::PROPERTY_GLOBAL_HEADER_IMAGE,
+                $instantArticle,
+                $node,
+                $this  
+              )
+            )
         }
 
         $body = $this->getProperty(self::PROPERTY_GLOBAL_BODY, $node);

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-ia.html
@@ -11,6 +11,9 @@
   <body>
     <article>
       <header>
+        <figure>
+          <img src="http://domain.com/header-image-body.png"/>
+        </figure>
         <h1>The <b>article</b> title</h1>
         <time class="op-published" datetime="2017-07-03T15:52:01+00:00">July 3rd, 3:52pm</time>
         <address><a href="http://facebook.com/author" rel="facebook" title="Journalist">Author Name</a>Some author description</address>

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules.json
@@ -47,6 +47,11 @@
                 "article.body":{
                     "selector":"article",
                     "type":"element"
+                },
+                "image.url":{
+                    "selector":"div.hero-image img",
+                    "type":"string",
+                    "attribute":"src"
                 }
             }
         },
@@ -172,19 +177,8 @@
             }
         },
         {
-            "class":"HeaderImageRule",
-            "selector":"div.hero-image",
-            "properties":{
-                "image.url":{
-                    "type":"string",
-                    "selector":"img",
-                    "attribute":"src"
-                },
-                "image.caption":{
-                    "type":"element",
-                    "selector":"div.image-caption"
-                }
-            }
+            "class":"IgnoreRule",
+            "selector":"div.hero-image"
         },
         {
             "class":"SocialEmbedRule",

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global.html
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global.html
@@ -14,6 +14,9 @@
                 <img src="http://domain.com/image-body.png"/>
                 <span class="caption">The caption for image.</span>
             </div>
+            <div class="hero-image">
+                <img src="http://domain.com/header-image-body.png"/>
+            </div>
             <div class="author">
                 By: <a href="http://facebook.com/author" title="Journalist">Author Name</a>
                 <span>Some author description</span>


### PR DESCRIPTION
This PR adds a global rule for header image

* Added a property for header image in GlobalRule
* Updated tests for GlobalRules

Follows #.
Related to #.
Fixes #.
