### PR TITLE
Fix for encoding problems into link attributes

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -60,6 +60,9 @@ abstract class Element
         $rendered = str_replace('></track>', '/>', $rendered);
         $rendered = str_replace('></wbr>', '/>', $rendered);
 
+        $rendered = preg_replace_callback('/(src|href|url|link)="([^"]*)"/is', [__CLASS__, 'urlDecoder'], $rendered);
+        // $rendered = htmlspecialchars_decode($rendered);
+
         return $rendered;
     }
 
@@ -121,5 +124,10 @@ abstract class Element
     public function disableEmptyValidation()
     {
         return $this->empty_validation = false;
+    }
+
+    public static function urlDecoder($input)
+    {
+        return $input[1].'="'.htmlspecialchars_decode($input[2]).'"';
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/AdTest.php
+++ b/tests/Facebook/InstantArticles/Elements/AdTest.php
@@ -100,4 +100,21 @@ class AdTest extends BaseHTMLTestCase
         $rendered = $ad->render();
         $this->assertEqualsHtml($expected, $rendered);
     }
+
+    public function testRenderEncoding()
+    {
+        $ad =
+            Ad::create()
+                ->withSource('http://foo.com?parameter=value1&param2=value2')
+                ->withHeight(640)
+                ->withWidth(480);
+
+        $expected =
+            '<figure class="op-ad">'.
+                '<iframe src="http://foo.com?parameter=value1&param2=value2" width="480" height="640"></iframe>'.
+            '</figure>';
+
+        $rendered = $ad->render();
+        $this->assertEqualsHtml($expected, $rendered);
+    }
 }

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -146,6 +146,28 @@ class ImageTest extends BaseHTMLTestCase
         $this->assertEqualsHtml($expected, $rendered);
     }
 
+    public function testRenderWithParameters()
+    {
+        $image =
+          Image::create()
+              ->withURL('https://jpeg.org/images/jpegls-home.jpg?width=100&height=200')
+              ->withCaption(
+                  Caption::create()
+                      ->appendText('Some caption to the image')
+              )
+              ->enableLike()
+              ->enableComments();
+
+        $expected =
+            '<figure data-feedback="fb:likes,fb:comments">'.
+                '<img src="https://jpeg.org/images/jpegls-home.jpg?width=100&height=200"/>'.
+                '<figcaption>Some caption to the image</figcaption>'.
+            '</figure>';
+
+        $rendered = $image->render();
+        $this->assertEqualsHtml($expected, $rendered);
+    }
+
     public function testRenderWithFullscreen()
     {
         $image =


### PR DESCRIPTION
This PR
* [x] Creates test cases that reproduces the problem
* [x] On render, treats the html special chars, like `&amp;` to be decoded as `&` only

Fixes #239
