### PR TITLE
Implemented logging structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you are encountering problems, the following tips may help in troubleshooting
 
 - If content is missing from your transformed article, more likely than not there isn't a **Transformer Rule** matching an element in your source markup. See how to configure appropriate rules for your content in the [Transformer Rules documentation](https://developers.facebook.com/docs/instant-articles/sdk/transformer-rules).
 
-- Set the `threshold` in the [configuration of the Logger](https://logging.apache.org/log4php/docs/configuration.html#PHP) to `DEBUG` to expose more details about the items processed by the Transformer.
+- Set the `threshold` in the transformer Logger level to `DEBUG` to expose more details about the items processed by the Transformer. `$transformer->setLogLevel(Transformer::LOG_DEBUG);`
 
 - Refer to the existing [tests of the `Elements`](https://github.com/facebook/facebook-instant-articles-sdk-php/tree/master/tests/Facebook/InstantArticles/Elements) for examples of what is required of each and to potentially create your own tests (which can be run with `$ composer test`).
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you are encountering problems, the following tips may help in troubleshooting
 
 - If content is missing from your transformed article, more likely than not there isn't a **Transformer Rule** matching an element in your source markup. See how to configure appropriate rules for your content in the [Transformer Rules documentation](https://developers.facebook.com/docs/instant-articles/sdk/transformer-rules).
 
-- Set the `threshold` in the transformer Logger level to `DEBUG` to expose more details about the items processed by the Transformer. `$transformer->setLogLevel(Transformer::LOG_DEBUG);`
+- Set the `threshold` in the transformer Logger level to `DEBUG` to expose more details about the items processed by the Transformer. `TransformerLog::setLevel(TransformerLog::DEBUG);`
 
 - Refer to the existing [tests of the `Elements`](https://github.com/facebook/facebook-instant-articles-sdk-php/tree/master/tests/Facebook/InstantArticles/Elements) for examples of what is required of each and to potentially create your own tests (which can be run with `$ composer test`).
 

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
     }],
     "require": {
         "php": "^5.4 || ^7.0",
-        "symfony/css-selector": "2.8.* || ^3.0",
-        "facebook/graph-sdk": "~5.0",
-        "apache/log4php": "2.3.0"
+        "symfony/css-selector": "2.8.*",
+        "facebook/graph-sdk": "~5.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6.0",
-        "phpunit/phpunit": "^4.8.36",
+        "phpunit/phpunit": "4.8.*",
+        "symfony/yaml": "2.1.*",
+        "phpdocumentor/reflection-docblock": "^2.0",
         "squizlabs/php_codesniffer": "^2.6.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,50 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "22ad829cbb45885884e2cb7e6b80c620",
+    "content-hash": "819d82438394df97c0ce9070c7e97930",
     "packages": [
         {
-            "name": "apache/log4php",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://git-wip-us.apache.org/repos/asf/logging-log4php.git",
-                "reference": "8c6df2481cd68d0d211d38f700406c5f0a9de0c2"
-            },
-            "require": {
-                "php": ">=5.2.7"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/main/php/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "A versatile logging framework for PHP",
-            "homepage": "http://logging.apache.org/log4php/",
-            "keywords": [
-                "log",
-                "logging",
-                "php"
-            ],
-            "time": "2012-10-26T09:13:25+00:00"
-        },
-        {
             "name": "facebook/graph-sdk",
-            "version": "5.4.2",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "2839246e971aef150650196acbb46d47e5207370"
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2839246e971aef150650196acbb46d47e5207370",
-                "reference": "2839246e971aef150650196acbb46d47e5207370",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
                 "shasum": ""
             },
             "require": {
@@ -92,20 +62,20 @@
                 "facebook",
                 "sdk"
             ],
-            "time": "2016-11-15T14:34:16+00:00"
+            "time": "2017-08-16T17:28:07+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.14",
+            "version": "v2.8.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "981abbbd6ba49af338a98490cbe29e7f39ca9fa9"
+                "reference": "c5b39674eacd34adedbef78227c57109caa9e318"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/981abbbd6ba49af338a98490cbe29e7f39ca9fa9",
-                "reference": "981abbbd6ba49af338a98490cbe29e7f39ca9fa9",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c5b39674eacd34adedbef78227c57109caa9e318",
+                "reference": "c5b39674eacd34adedbef78227c57109caa9e318",
                 "shasum": ""
             },
             "require": {
@@ -145,7 +115,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03T07:52:58+00:00"
+            "time": "2018-01-03T07:36:31+00:00"
         }
     ],
     "packages-dev": [
@@ -205,29 +175,31 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.6.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
             },
             "type": "library",
             "extra": {
-                "branch-alias": []
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -249,20 +221,20 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
@@ -298,37 +270,37 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03T12:10:50+00:00"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -361,7 +333,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21T14:58:47+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -427,16 +399,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -470,7 +442,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21T13:08:43+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -515,25 +487,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -555,20 +532,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +581,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -736,16 +713,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
@@ -796,27 +773,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19T09:18:40+00:00"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -848,7 +825,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1020,16 +997,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1069,7 +1046,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11T19:50:13+00:00"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1108,16 +1085,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -1182,38 +1159,31 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01T23:53:02+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.14",
+            "version": "v2.1.13",
+            "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
+                "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/347a7a02204433c6926ecc3f13e805bdc30e8f9f",
+                "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                "psr-0": {
+                    "Symfony\\Component\\Yaml": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1221,17 +1191,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
                 },
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-11-14T16:15:57+00:00"
+            "homepage": "http://symfony.com",
+            "time": "2013-05-10T00:09:46+00:00"
         }
     ],
     "aliases": [],

--- a/src/Facebook/InstantArticles/Client/InstantArticleStatus.php
+++ b/src/Facebook/InstantArticles/Client/InstantArticleStatus.php
@@ -50,7 +50,7 @@ class InstantArticleStatus
     }
 
     /**
-    * Creates a instance from a status string,.
+    * Creates a instance from a status string.
     *
     * @param string $status the status string, case insensitive.
     * @param array $messages the message from the server
@@ -72,8 +72,6 @@ class InstantArticleStatus
         if ($validStatus) {
             return new self($status, $messages);
         } else {
-            \Logger::getLogger('facebook-instantarticles-client')
-                ->info("Unknown status '$status'. Are you using the last SDK version?");
             return new self(self::UNKNOWN, $messages);
         }
     }

--- a/src/Facebook/InstantArticles/Client/ServerMessage.php
+++ b/src/Facebook/InstantArticles/Client/ServerMessage.php
@@ -73,8 +73,6 @@ class ServerMessage
         if ($validLevel) {
             return new self($level, $message);
         } else {
-            \Logger::getLogger('facebook-instantarticles-client')
-                ->info('Unknown message level "$level". Are you using the last SDK version?');
             return new self(self::INFO, $message);
         }
     }

--- a/src/Facebook/InstantArticles/Transformer/Logs/TransformerLog.php
+++ b/src/Facebook/InstantArticles/Transformer/Logs/TransformerLog.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Logs;
+
+use Facebook\InstantArticles\Elements\Element;
+use Facebook\InstantArticles\Validators\Type;
+
+class TransformerLog
+{
+    /**
+     * OFF means no log will be generated during transformation.
+     */
+    const OFF = 'OFF';
+
+    /**
+     * INFO **default** Just the informative logs will be turned on.
+     */
+    const INFO = 'INFO';
+
+    /**
+     * DEBUG means all verbose information will be active for debugging purposes.
+     */
+    const DEBUG = 'DEBUG';
+
+    /**
+     * ERROR means only errors will be shown.
+     */
+    const ERROR = 'ERROR';
+
+    private static $LOG_DEFINITION = array(
+        self::OFF => 0,
+        self::ERROR => 1,
+        self::INFO => 2,
+        self::DEBUG => 3
+    );
+
+    /**
+     * @var string $logLevel The log level set into this transformer instance. Possible values: OFF, INFO or DEBUG
+     */
+    private static $logLevel = self::INFO;
+
+    /**
+     * @var The log level
+     */
+    private $level;
+
+    /**
+     * @var String the log message
+     */
+    private $message;
+
+    /**
+     * @param string $level. Can be any of these: @see TransformerLog::OFF, @see TransformerLog::INFO, @see TransformerLog::DEBUG, @see TransformerLog::ERROR
+     * @param string $message The log message itself
+     */
+    public function __construct($level, $message)
+    {
+        $level = strtoupper($level);
+        Type::enforceWithin(
+            $level,
+            [
+                self::OFF,
+                self::INFO,
+                self::DEBUG,
+                self::ERROR
+            ]
+        );
+        $this->level = $level;
+        $this->message = $message;
+    }
+
+    /**
+     * Sets the log level from transformer. This should be set before @see Transformer::transform or @see Transformer::transformString are called.
+     * The default level is TransformerLog::INFO
+     * @param $level string The log level to be setted.
+     * @see TransformerLog::OFF, TransformerLog::INFO, TransformerLog::DEBUG, TransformerLog::ERROR
+     */
+    public static function setLevel($level)
+    {
+        $level = strtoupper($level);
+        Type::enforceWithin(
+            $level,
+            [
+                self::OFF,
+                self::INFO,
+                self::DEBUG,
+                self::ERROR
+            ]
+        );
+        self::$logLevel = $level;
+    }
+
+    /**
+     * @return bool if $level informed is compatible with the @see self::setLogLevel.
+     * $level must be >= than @see self::setLogLevel.
+     * Order of levels:  OFF < DEBUG < INFO < ERROR
+     */
+    public static function isLevelEnabled($level)
+    {
+        $logLevel = self::$LOG_DEFINITION[self::$logLevel];
+        $levelChecked = self::$LOG_DEFINITION[$level];
+
+        return $logLevel >= $levelChecked;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return "[$this->level] $this->message";
+    }
+
+    /**
+     * @return string Message level
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * @return string Message
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/Rule.php
@@ -10,30 +10,14 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 abstract class Rule
 {
+    /**
+     * @deprecated Do not rely on the implementation of this method. Instead, be sure to
+     * implement @see Rule::matchesNode and @see Rule::matchesContext, as they are used
+     * separetedly by the @see Transformer.
+     */
     public function matches($context, $node)
     {
-        $log = \Logger::getLogger('facebook-instantarticles-transformer');
-
-        $matches_context = $this->matchesContext($context);
-        $matches_node = $this->matchesNode($node);
-        if ($matches_context && $matches_node) {
-            $log->debug('context class: '.get_class($context));
-            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
-            $log->debug('node name: <'.$node->nodeName.' />');
-            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
-            $log->debug('rule: '.get_class($this));
-            $log->debug('-------');
-        }
-        if ($node->nodeName === 'iframe') {
-            $log->debug('context class: '.get_class($context));
-            $log->debug('context matches: '.($matches_context ? 'MATCHES' : 'no match'));
-            $log->debug('node name: <'.$node->nodeName.' />');
-            $log->debug('node: '.$node->ownerDocument->saveXML($node).' />');
-            $log->debug('node matches: '.($matches_node ? 'MATCHES' : 'no match'));
-            $log->debug('rule: '.get_class($this));
-            $log->debug('-------');
-        }
-        return $matches_context && $matches_node;
+        return $this->matchesContext($context) && $this->matchesNode($node);
     }
 
     abstract public function matchesContext($context);

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -58,6 +58,43 @@ class Transformer
     const INSTANT_ARTICLES_PARSED_FLAG = 'data-instant-articles-element-processed';
 
     /**
+     * LOG_NOLOG means no log will be generated during transformation.
+     */
+    const LOG_OFF = 'OFF';
+
+    /**
+     * LOG_INFO **default** Just the informative logs will be turned on.
+     */
+    const LOG_INFO = 'INFO';
+
+    /**
+     * LOG_DEBUG means all verbose information will be active for debugging purposes.
+     */
+    const LOG_DEBUG = 'DEBUG';
+
+    /**
+     * LOG_ERROR means only errors will be shown.
+     */
+    const LOG_ERROR = 'ERROR';
+
+    private static $LOG_DEFINITION = array(
+        self::LOG_OFF => 0,
+        self::LOG_ERROR => 1,
+        self::LOG_INFO => 2,
+        self::LOG_DEBUG => 3
+    );
+
+    /**
+     * @var string $logLevel The log level set into this transformer instance. Possible values: LOG_NOLOG, LOG_INFO or LOG_DEBUG
+     */
+    private $logLevel = self::LOG_INFO;
+
+    /**
+     * @var string[] $logs The log messages generated during the transformation process.
+     */
+    private $logs = ['Possible log levels: OFF, ERROR, INFO or DEBUG'];
+
+    /**
      * Initializes default values.
      */
     public function __construct()
@@ -178,6 +215,69 @@ class Transformer
     }
 
     /**
+     * Sets the log level from transformer. This should be set before @see Transformer::transform or @see Transformer::transformString are called.
+     * @param $level string The log level to be setted.
+     * @see Transformer::LOG_OFF, Transformer::LOG_INFO, Transformer::LOG_DEBUG
+     */
+    public function setLogLevel($level)
+    {
+        $level = strtoupper($level);
+        Type::enforceWithin(
+            $level,
+            [
+                self::LOG_OFF,
+                self::LOG_INFO,
+                self::LOG_DEBUG,
+                self::LOG_ERROR
+            ]
+        );
+        $this->logLevel = $level;
+    }
+
+    /**
+     * @param $level string The log level message to be added. It will ignore if the level used at @see self::setLogLevel is not proper for this level message.
+     * @param $logMessage string the Log message that will be added if the $level informed is proper based on @see self::setLogLevel.
+     */
+    public function addLog($level, $logMessage)
+    {
+        $level = strtoupper($level);
+        Type::enforceWithin(
+            $level,
+            [
+                self::LOG_OFF,
+                self::LOG_INFO,
+                self::LOG_DEBUG,
+                self::LOG_ERROR
+            ]
+        );
+        if ($this->isLogLevelEnabled($level)) {
+            $this->logs[] = "[$level] $logMessage";
+        }
+    }
+
+    /**
+     * @return bool if $level informed is compatible with the @see self::setLogLevel.
+     * $level must be >= than @see self::setLogLevel.
+     * Order of levels:  LOG_OFF < LOG_DEBUG < LOG_INFO
+     */
+    private function isLogLevelEnabled($level)
+    {
+        $logLevel = self::$LOG_DEFINITION[$this->logLevel];
+        $levelChecked = self::$LOG_DEFINITION[$level];
+
+        return $logLevel >= $levelChecked;
+    }
+
+    /**
+     * Get the log information during the transformation. This should be called once, after transformation is finished already.
+     * @return string[] With each message being one item on this array.
+     */
+    public function getLogs()
+    {
+        return $this->logs;
+    }
+
+    /**
      * @param InstantArticle $context
      * @param string $content
      *
@@ -185,13 +285,22 @@ class Transformer
      */
     public function transformString($context, $content, $encoding = "utf-8")
     {
+        $start = microtime(true);
+        $this->addLog(
+            self::LOG_INFO,
+            "Transformer initiated using encode [$encoding]"
+        );
+        $this->addLog(
+            self::LOG_DEBUG,
+            "Will transform content [$content]"
+        );
         $libxml_previous_state = libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
         if (function_exists('mb_convert_encoding')) {
             $document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', $encoding));
         } else {
-            $log = \Logger::getLogger('facebook-instantarticles-transformer');
-            $log->debug(
+            $this->addLog(
+                LOG_DEBUG,
                 'Your content encoding is "' . $encoding . '" ' .
                 'but your PHP environment does not have mbstring. Trying to load your content with using meta tags.'
             );
@@ -204,12 +313,20 @@ class Transformer
         }
         libxml_clear_errors();
         libxml_use_internal_errors($libxml_previous_state);
-        return $this->transform($context, $document);
+        $result = $this->transform($context, $document);
+        $totalTime = round((microtime(true) - $start), 3)*1000;
+        $totalWarnings = count($this->getWarnings());
+        $this->addLog(
+            self::LOG_INFO,
+            "Transformer finished in $totalTime ms with ($totalWarnings) warnings"
+        );
+        return $result;
     }
 
     /**
      * @param InstantArticle $context
      * @param \DOMNode $node
+     * @deprecated Use @see Transformer::transformString instead.
      *
      * @return mixed
      */
@@ -221,10 +338,10 @@ class Transformer
             $this->instantArticle = $context;
         }
 
-        $log = \Logger::getLogger('facebook-instantarticles-transformer');
         if (!$node) {
             $e = new \Exception();
-            $log->error(
+            $this->addLog(
+                self::LOG_ERROR,
                 'Transformer::transform($context, $node) requires $node'.
                 ' to be a valid one. Check on the stacktrace if this is '.
                 'some nested transform operation and fix the selector.',
@@ -238,8 +355,6 @@ class Transformer
                     continue;
                 }
                 $matched = false;
-                $log->debug("===========================");
-                $log->debug($child->ownerDocument->saveHtml($child));
 
                 // Get all classes and interfaces this context extends/implements
                 $contextClassNames = self::getAllClassTypes($context->getClassName());
@@ -261,12 +376,22 @@ class Transformer
                 $matchingContextRules = array_reverse($matchingContextRules);
                 foreach ($matchingContextRules as $rule) {
                     // We know context was matched, now check if it matches the node
+                    $className = $rule->getClassName();
                     if ($rule->matchesNode($child)) {
+                        $this->addLog(
+                            self::LOG_DEBUG,
+                            "MATCH -> Rule [$className] applied to node [$child->nodeName]"
+                        );
                         $current_context = $rule->apply($this, $current_context, $child);
                         $matched = true;
 
                         // Just a single rule for each node, so move on
                         break;
+                    } else {
+                        $this->addLog(
+                            self::LOG_DEBUG,
+                            "no match -> rule [$className] not matched to node [$child->nodeName]"
+                        );
                     }
                 }
 
@@ -280,11 +405,16 @@ class Transformer
                     $tag_content = $child->ownerDocument->saveXML($child);
                     $tag_trimmed = trim($tag_content);
                     if (!empty($tag_trimmed)) {
-                        $log->debug('context class: '.get_class($context));
-                        $log->debug('node name: '.$child->nodeName);
-                        $log->debug("CONTENT NOT MATCHED: \n".$tag_content);
+                        $className = $context->getClassName();
+                        $this->addLog(
+                            self::LOG_ERROR,
+                            "Content with no rules matching! Context[$className] and Node [$child->nodeName]"
+                        );
                     } else {
-                        $log->debug('empty content ignored');
+                        $this->addLog(
+                            self::LOG_DEBUG,
+                            "Empty content ignored."
+                        );
                     }
 
                     $this->addWarning(new UnrecognizedElement($current_context, $child));

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Transformer\Logs\TransformerLog;
 use Facebook\Util\BaseHTMLTestCase;
 
 class SimpleTransformerTest extends BaseHTMLTestCase
@@ -37,8 +38,8 @@ class SimpleTransformerTest extends BaseHTMLTestCase
     public function testDebugLog()
     {
         $expected = array(
-            'Possible log levels: OFF, ERROR, INFO or DEBUG',
-            '[INFO] Transformer initiated using encode [utf-8]',
+            new TransformerLog(TransformerLog::INFO, 'Possible log levels: OFF, ERROR, INFO or DEBUG. To change it call method TransformerLog::setLevel("DEBUG").'),
+            new TransformerLog(TransformerLog::INFO, 'Transformer initiated using encode [utf-8]')
         );
         $json_file = file_get_contents(__DIR__ . '/simple-rules.json');
 
@@ -48,7 +49,7 @@ class SimpleTransformerTest extends BaseHTMLTestCase
 
         $html_file = file_get_contents(__DIR__ . '/simple.html');
 
-        $transformer->setLogLevel(Transformer::LOG_DEBUG);
+        TransformerLog::setLevel(TransformerLog::DEBUG);
         $transformer->transformString($instant_article, $html_file);
         $result = array($transformer->getLogs()[0], $transformer->getLogs()[1]);
 

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -23,12 +23,7 @@ class SimpleTransformerTest extends BaseHTMLTestCase
 
         $html_file = file_get_contents(__DIR__ . '/simple.html');
 
-        libxml_use_internal_errors(true);
-        $document = new \DOMDocument();
-        $document->loadHTML($html_file);
-        libxml_use_internal_errors(false);
-
-        $transformer->transform($instant_article, $document);
+        $transformer->transformString($instant_article, $html_file);
         $instant_article->addMetaProperty('op:generator:version', '1.0.0');
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
@@ -36,6 +31,27 @@ class SimpleTransformerTest extends BaseHTMLTestCase
 
         //var_dump($result);
         // print_r($warnings);
+        $this->assertEqualsHtml($expected, $result);
+    }
+
+    public function testDebugLog()
+    {
+        $expected = array(
+            'Possible log levels: OFF, ERROR, INFO or DEBUG',
+            '[INFO] Transformer initiated using encode [utf-8]',
+        );
+        $json_file = file_get_contents(__DIR__ . '/simple-rules.json');
+
+        $instant_article = InstantArticle::create();
+        $transformer = new Transformer();
+        $transformer->loadRules($json_file);
+
+        $html_file = file_get_contents(__DIR__ . '/simple.html');
+
+        $transformer->setLogLevel(Transformer::LOG_DEBUG);
+        $transformer->transformString($instant_article, $html_file);
+        $result = array($transformer->getLogs()[0], $transformer->getLogs()[1]);
+
         $this->assertEqualsHtml($expected, $result);
     }
 }

--- a/tests/Facebook/Util/BaseHTMLTestCase.php
+++ b/tests/Facebook/Util/BaseHTMLTestCase.php
@@ -12,26 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseHTMLTestCase extends TestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     protected function assertEqualsHtml($expected, $actual)
     {
         $from = ['/\>[^\S ]+/s', '/[^\S ]+\</s', '/(\s)+/s', '/> </s'];


### PR DESCRIPTION
* [x] Implemented a simple internal logging structure.
* [x] Removed log4php
* [x] Fixed #302
* [x] Fixed #245
* [x] Fixed #240

Calls to Transformer have now stored all logging messages:
```
        $json_file = file_get_contents(__DIR__ . '/simple-rules.json');

        $instant_article = InstantArticle::create();
        $transformer = new Transformer();
        $transformer->loadRules($json_file);

        $html_file = file_get_contents(__DIR__ . '/simple.html');

        TransformerLog::setLevel(TransformerLog::DEBUG);
        $transformer->transformString($instant_article, $html_file);
        $result = $transformer->getLogs();
```