### PR TITLE
Now cloning elements only in the right rules (interactive, ads, analy…

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/ElementGetter.php
@@ -55,7 +55,7 @@ class ElementGetter extends AbstractGetter
         $elements = self::findAll($node, $this->selector);
         if (!empty($elements) && property_exists($elements, 'length') && $elements->length !== 0) {
             Transformer::markAsProcessed($elements->item(0));
-            return Transformer::cloneNode($elements->item(0));
+            return $elements->item(0);
         }
         return null;
     }

--- a/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/MultipleElementsGetter.php
@@ -31,7 +31,7 @@ class MultipleElementsGetter extends AbstractGetter
     {
         $fragment = $node->ownerDocument->createDocumentFragment();
         foreach ($this->children as $child) {
-            $cloned_node = $child->get($node);
+            $cloned_node = Transformer::cloneNode($child->get($node));
             if (Type::is($cloned_node, 'DOMNode')) {
                 $fragment->appendChild($cloned_node);
             }

--- a/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AdRule.php
@@ -10,6 +10,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Ad;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AdRule extends ConfigurationSelectorRule
@@ -69,7 +70,7 @@ class AdRule extends ConfigurationSelectorRule
 
         $embed_code = $this->getProperty(self::PROPERTY_AD_EMBED_URL, $node);
         if ($embed_code) {
-            $ad->withHTML($embed_code);
+            $ad->withHTML(Transformer::cloneNode($embed_code));
         }
 
         if ($url || $embed_code) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/AnalyticsRule.php
@@ -10,6 +10,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Analytics;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 
 class AnalyticsRule extends ConfigurationSelectorRule
@@ -55,7 +56,7 @@ class AnalyticsRule extends ConfigurationSelectorRule
 
         $embed_code = $this->getProperty(self::PROPERTY_TRACKER_EMBED_URL, $node);
         if ($embed_code) {
-            $analytics->withHTML($embed_code);
+            $analytics->withHTML(Transformer::cloneNode($embed_code));
         }
 
         if ($url || $embed_code) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/HeaderAdRule.php
@@ -10,6 +10,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Ad;
+use Facebook\InstantArticles\Transformer\Transformer;
 
 class HeaderAdRule extends ConfigurationSelectorRule
 {
@@ -68,7 +69,7 @@ class HeaderAdRule extends ConfigurationSelectorRule
 
         $embed_code = $this->getProperty(self::PROPERTY_AD_EMBED_URL, $node);
         if ($embed_code) {
-            $ad->withHTML($embed_code);
+            $ad->withHTML(Transformer::cloneNode($embed_code));
         }
 
         if ($url || $embed_code) {

--- a/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/InteractiveRule.php
@@ -11,6 +11,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 use Facebook\InstantArticles\Elements\Interactive;
 use Facebook\InstantArticles\Elements\Paragraph;
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 use Facebook\InstantArticles\Validators\Type;
 
@@ -81,7 +82,7 @@ class InteractiveRule extends ConfigurationSelectorRule
         $iframe = $this->getProperty(self::PROPERTY_IFRAME, $node);
         $url = $this->getProperty(self::PROPERTY_URL, $node);
         if ($iframe) {
-            $interactive->withHTML($iframe);
+            $interactive->withHTML(Transformer::cloneNode($iframe));
         }
         if ($url) {
             $interactive->withSource($url);

--- a/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
+++ b/src/Facebook/InstantArticles/Transformer/Rules/SocialEmbedRule.php
@@ -10,6 +10,7 @@ namespace Facebook\InstantArticles\Transformer\Rules;
 
 use Facebook\InstantArticles\Elements\SocialEmbed;
 use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Transformer\Warnings\InvalidSelector;
 use Facebook\InstantArticles\Transformer\Warnings\DeprecatedRuleWarning;
 
@@ -59,7 +60,7 @@ class SocialEmbedRule extends ConfigurationSelectorRule
         $iframe = $this->getProperty(self::PROPERTY_IFRAME, $node);
         $url = $this->getProperty(self::PROPERTY_URL, $node);
         if ($iframe) {
-            $social_embed->withHTML($iframe);
+            $social_embed->withHTML(Transformer::cloneNode($iframe));
         }
         if ($url) {
             $social_embed->withSource($url);

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -30,8 +30,6 @@ class SimpleTransformerTest extends BaseHTMLTestCase
         $result = $instant_article->render('', true)."\n";
         $expected = file_get_contents(__DIR__ . '/simple-ia.html');
 
-        //var_dump($result);
-        // print_r($warnings);
         $this->assertEqualsHtml($expected, $result);
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -6,19 +6,7 @@
             },
             {
                 "class": "PassThroughRule",
-                "selector" : "html"
-            },
-            {
-                "class": "PassThroughRule",
-                "selector" : "head"
-            },
-            {
-                "class": "PassThroughRule",
-                "selector" : "script"
-            },
-            {
-                "class": "PassThroughRule",
-                "selector" : "body"
+                "selector" : "html, head, script, body"
             },
             {
                 "class": "ItalicRule",

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules.json
@@ -57,15 +57,7 @@
         },
         {
             "class":"PassThroughRule",
-            "selector":"head"
-        },
-        {
-            "class":"PassThroughRule",
-            "selector":"script"
-        },
-        {
-            "class":"PassThroughRule",
-            "selector":"body"
+            "selector":"head, script, body"
         },
         {
             "class":"ItalicRule",

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
@@ -94,6 +94,31 @@
         <script>alert('hi & hello to you @ testing!');</script>
       </iframe>
       </figure>
+      <figure class="op-ad">
+        <iframe src="https://www.adserver.com/ss;adtype=banner300x250"></iframe>
+      </figure>
+      <figure class="op-ad">
+          <iframe width="250" height="300">
+          <script>
+            window.addEventListener('message', receiveMessage);
+
+            function receiveMessage(event) {
+              if (event.data === 'enters_viewport') {
+                // ad entered viewport
+              }
+            }
+          </script>
+          </iframe>
+      </figure>
+      <figure class="op-tracker">
+          <iframe src="https://www.myserver.com/trackingcode"></iframe>
+      </figure>
+      <figure class="op-tracker">
+        <iframe>
+          <!-- Include full analytics code here -->
+          <script>alert('testing analytics!');</script>
+        </iframe>
+      </figure>
       <figure class="op-interactive">
         <iframe class="no-margin" height="200">
           <table width="200" height="200">

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
@@ -639,7 +639,78 @@
                 "selector": "p.credit"
             }
         }
+    },
+    {
+        "class": "AdRule",
+        "selector" : "div.ad",
+        "properties" : {
+            "ad.embed" : {
+                "type" : "children",
+                "selector" : "div.ad"
+            },
+            "ad.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            },
+            "ad.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            }
+        }
+    },
+    {
+        "class": "AdRule",
+        "selector": "//div[@class='ad' and iframe]",
+        "properties" : {
+            "ad.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "ad.embed" : {
+                "type" : "children",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "ad.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            },
+            "ad.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            }
+        }
+    },
+    {
+        "class": "AnalyticsRule",
+        "selector": "//div[@class='analytics' and iframe]",
+        "properties" : {
+            "analytics.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "analytics.embed" : {
+                "type" : "children",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "analytics.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            },
+            "analytics.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            }
+        }
     }
-
   ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/custom.html
+++ b/tests/Facebook/InstantArticles/Transformer/custom.html
@@ -50,6 +50,31 @@
         <script>alert('hi & hello to you @ testing!');</script>
       </iframe>
     </div>
+    <div class="ad">
+        <iframe src="https://www.adserver.com/ss;adtype=banner300x250"></iframe>
+    </div>
+    <div class="ad">
+        <iframe height="300" width="250">
+        <script>
+          window.addEventListener('message', receiveMessage);
+
+          function receiveMessage(event) {
+            if (event.data === 'enters_viewport') {
+              // ad entered viewport
+            }
+          }
+        </script>
+        </iframe>
+    </div>
+    <div class="analytics">
+        <iframe src="https://www.myserver.com/trackingcode"></iframe>
+    </div>
+    <div class="analytics">
+      <iframe>
+        <!-- Include full analytics code here -->
+        <script>alert('testing analytics!');</script>
+      </iframe>
+    </div>
     <table width="200" height="200">
       <thead>
         <td>header 1</td>


### PR DESCRIPTION
…tics)

This PR changes the logic in a way that now we only clone the embeds/iframe for only the right elements (Interactive, Ads, Analytics, SocialEmbeds). 

This fixes the xpath element evaluation that wasn't working when a rule had selectors with comma.  