### PR TITLE
Fixed Anchor isValid check / using a instead of Anchor in RelatedItem…

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Ad.php
+++ b/src/Facebook/InstantArticles/Elements/Ad.php
@@ -167,10 +167,6 @@ class Ad extends ElementWithHTML
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $figure = $document->createElement('figure');
         $iframe = $document->createElement('iframe');
 

--- a/src/Facebook/InstantArticles/Elements/Analytics.php
+++ b/src/Facebook/InstantArticles/Elements/Analytics.php
@@ -82,10 +82,6 @@ class Analytics extends ElementWithHTML
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $figure = $document->createElement('figure');
         $iframe = $document->createElement('iframe');
 

--- a/src/Facebook/InstantArticles/Elements/Anchor.php
+++ b/src/Facebook/InstantArticles/Elements/Anchor.php
@@ -92,10 +92,6 @@ class Anchor extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $anchor = $document->createElement('a');
 
         if ($this->href) {
@@ -117,6 +113,7 @@ class Anchor extends FormattedText
      */
     public function isValid()
     {
-        return !Type::isTextEmpty($this->href);
+        return !Type::isTextEmpty($this->href) && parent::isValid();
     }
+
 }

--- a/src/Facebook/InstantArticles/Elements/Anchor.php
+++ b/src/Facebook/InstantArticles/Elements/Anchor.php
@@ -115,5 +115,4 @@ class Anchor extends FormattedText
     {
         return !Type::isTextEmpty($this->href) && parent::isValid();
     }
-
 }

--- a/src/Facebook/InstantArticles/Elements/Audio.php
+++ b/src/Facebook/InstantArticles/Elements/Audio.php
@@ -191,10 +191,6 @@ class Audio extends Element
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('audio');
 
         // title markup optional

--- a/src/Facebook/InstantArticles/Elements/Author.php
+++ b/src/Facebook/InstantArticles/Elements/Author.php
@@ -173,10 +173,6 @@ class Author extends Element
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $author_url = $this->url ? $this->url : null;
         $is_fb_author = strpos($author_url, 'facebook.com') !== false;
 

--- a/src/Facebook/InstantArticles/Elements/Blockquote.php
+++ b/src/Facebook/InstantArticles/Elements/Blockquote.php
@@ -84,10 +84,6 @@ class Blockquote extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('blockquote');
 
         $element->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Bold.php
+++ b/src/Facebook/InstantArticles/Elements/Bold.php
@@ -40,10 +40,6 @@ class Bold extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $bold = $document->createElement('b');
 
         $bold->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Caption.php
+++ b/src/Facebook/InstantArticles/Elements/Caption.php
@@ -362,30 +362,22 @@ class Caption extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('figcaption');
 
         // title markup REQUIRED
         if ($this->title && (!$this->subTitle && !$this->credit)) {
             $element->appendChild($this->title->textToDOMDocumentFragment($document));
-        } elseif ($this->title) {
-            $element->appendChild($this->title->toDOMElement($document));
+        } else {
+            Element::appendChild($element, $this->title, $document);
         }
 
         // subtitle markup optional
-        if ($this->subTitle) {
-            $element->appendChild($this->subTitle->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->subTitle, $document);
 
         $element->appendChild($this->textToDOMDocumentFragment($document));
 
         // credit markup optional
-        if ($this->credit) {
-            $element->appendChild($this->credit->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->credit, $document);
 
         // Formating markup
         if ($this->textAlignment || $this->verticalAlignment || $this->fontSize || $this->position) {

--- a/src/Facebook/InstantArticles/Elements/Cite.php
+++ b/src/Facebook/InstantArticles/Elements/Cite.php
@@ -148,10 +148,6 @@ class Cite extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $cite = $document->createElement('cite');
 
         $classes = [];

--- a/src/Facebook/InstantArticles/Elements/Div.php
+++ b/src/Facebook/InstantArticles/Elements/Div.php
@@ -40,10 +40,6 @@ class Div extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $div = $document->createElement('div');
 
         $div->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -123,7 +123,8 @@ abstract class Element
         return $input[1].'="'.htmlspecialchars_decode($input[2]).'"';
     }
 
-    public static function appendChild($element, $child, $document = null) {
+    public static function appendChild($element, $child, $document = null)
+    {
         if ($child !== null && $child->isValid()) {
             $element->appendChild($child->toDOMElement($document));
         }

--- a/src/Facebook/InstantArticles/Elements/Emphasized.php
+++ b/src/Facebook/InstantArticles/Elements/Emphasized.php
@@ -40,10 +40,6 @@ class Emphasized extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $emphasized = $document->createElement('em');
 
         $emphasized->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Footer.php
+++ b/src/Facebook/InstantArticles/Elements/Footer.php
@@ -168,10 +168,6 @@ class Footer extends Element implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $footer = $document->createElement('footer');
 
         // Footer markup
@@ -179,7 +175,7 @@ class Footer extends Element implements ChildrenContainer
             $aside = $document->createElement('aside');
             if (is_array($this->credits)) {
                 foreach ($this->credits as $paragraph) {
-                    $aside->appendChild($paragraph->toDOMElement($document));
+                    Element::appendChild($aside, $paragraph, $document);
                 }
             } else {
                 $aside->appendChild($document->createTextNode($this->credits));
@@ -193,13 +189,11 @@ class Footer extends Element implements ChildrenContainer
                 $small->appendChild($document->createTextNode($this->copyright));
                 $footer->appendChild($small);
             } else {
-                $footer->appendChild($this->copyright->toDOMElement($document));
+                Element::appendChild($footer, $this->copyright, $document);
             }
         }
 
-        if ($this->relatedArticles) {
-            $footer->appendChild($this->relatedArticles->toDOMElement($document));
-        }
+        Element::appendChild($footer, $this->relatedArticles, $document);
 
         if (!$this->credits && !$this->copyright && !$this->relatedArticles) {
             $footer->appendChild($document->createTextNode(''));

--- a/src/Facebook/InstantArticles/Elements/GeoTag.php
+++ b/src/Facebook/InstantArticles/Elements/GeoTag.php
@@ -91,10 +91,6 @@ class GeoTag extends Element
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('script');
         $element->setAttribute('type', 'application/json');
         $element->setAttribute('class', 'op-geotag');

--- a/src/Facebook/InstantArticles/Elements/H1.php
+++ b/src/Facebook/InstantArticles/Elements/H1.php
@@ -118,10 +118,6 @@ class H1 extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $h1 = $document->createElement('h1');
 
         $classes = [];

--- a/src/Facebook/InstantArticles/Elements/H2.php
+++ b/src/Facebook/InstantArticles/Elements/H2.php
@@ -119,10 +119,6 @@ class H2 extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $h2 = $document->createElement('h2');
 
         $classes = [];

--- a/src/Facebook/InstantArticles/Elements/H3.php
+++ b/src/Facebook/InstantArticles/Elements/H3.php
@@ -111,10 +111,6 @@ class H3 extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $h3 = $document->createElement('h3');
 
         $classes = [];

--- a/src/Facebook/InstantArticles/Elements/Header.php
+++ b/src/Facebook/InstantArticles/Elements/Header.php
@@ -388,39 +388,17 @@ class Header extends Element implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('header');
 
-        if ($this->cover && $this->cover->isValid()) {
-            $element->appendChild($this->cover->toDOMElement($document));
-        }
-
-        if ($this->title && $this->title->isValid()) {
-            $element->appendChild($this->title->toDOMElement($document));
-        }
-
-        if ($this->subtitle && $this->subtitle->isValid()) {
-            $element->appendChild($this->subtitle->toDOMElement($document));
-        }
-
-        if ($this->published && $this->published->isValid()) {
-            $published_element = $this->published->toDOMElement($document);
-            $element->appendChild($published_element);
-        }
-
-        if ($this->modified && $this->modified->isValid()) {
-            $modified_element = $this->modified->toDOMElement($document);
-            $element->appendChild($modified_element);
-        }
+        Element::appendChild($element, $this->cover, $document);
+        Element::appendChild($element, $this->title, $document);
+        Element::appendChild($element, $this->subtitle, $document);
+        Element::appendChild($element, $this->published, $document);
+        Element::appendChild($element, $this->modified, $document);
 
         if ($this->authors) {
             foreach ($this->authors as $author) {
-                if ($author->isValid()) {
-                    $element->appendChild($author->toDOMElement($document));
-                }
+                Element::appendChild($element, $author, $document);
             }
         }
 
@@ -432,9 +410,7 @@ class Header extends Element implements ChildrenContainer
 
         if (count($this->ads) === 1) {
             $this->ads[0]->disableDefaultForReuse();
-            if ($this->ads[0]->isValid()) {
-                $element->appendChild($this->ads[0]->toDOMElement($document));
-            }
+            Element::appendChild($element, $this->ads[0], $document);
         } elseif (count($this->ads) >= 2) {
             $ads_container = $document->createElement('section');
             $ads_container->setAttribute('class', 'op-ad-template');
@@ -460,9 +436,7 @@ class Header extends Element implements ChildrenContainer
             }
         }
 
-        if ($this->sponsor && $this->sponsor->isValid()) {
-            $element->appendChild($this->sponsor->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->sponsor, $document);
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -312,10 +312,6 @@ class Image extends Audible
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('figure');
 
         // Like/comments markup optional
@@ -342,19 +338,13 @@ class Image extends Audible
         }
 
         // Caption markup optional
-        if ($this->caption) {
-            $element->appendChild($this->caption->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->caption, $document);
 
         // Geotag markup optional
-        if ($this->geoTag) {
-            $element->appendChild($this->geoTag->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->geoTag, $document);
 
         // Audio markup optional
-        if ($this->audio) {
-            $element->appendChild($this->audio->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->audio, $document);
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -478,10 +478,10 @@ class InstantArticle extends Element implements ChildrenContainer, InstantArticl
         return $this;
     }
 
-    public function render($doctype = '<!doctype html>', $format = false)
+    public function render($doctype = '<!doctype html>', $format = false, $validate = true)
     {
         $doctype = is_null($doctype) ? '<!doctype html>' : $doctype;
-        return parent::render($doctype, $format);
+        return parent::render($doctype, $format, false);
     }
 
     public function toDOMElement($document = null)
@@ -546,9 +546,7 @@ class InstantArticle extends Element implements ChildrenContainer, InstantArticl
         $article = $document->createElement('article');
         $body->appendChild($article);
         $html->appendChild($body);
-        if ($this->header && $this->header->isValid()) {
-            $article->appendChild($this->header->toDOMElement($document));
-        }
+        Element::appendChild($article, $this->header, $document);
         if ($this->children) {
             foreach ($this->children as $child) {
                 if (Type::is($child, TextContainer::getClassName())) {
@@ -561,11 +559,9 @@ class InstantArticle extends Element implements ChildrenContainer, InstantArticl
                         }
                     }
                 }
-                $article->appendChild($child->toDOMElement($document));
+                Element::appendChild($article, $child, $document);
             }
-            if ($this->footer && $this->footer->isValid()) {
-                $article->appendChild($this->footer->toDOMElement($document));
-            }
+            Element::appendChild($article, $this->footer, $document);
         } else {
             $article->appendChild($document->createTextNode(''));
         }

--- a/src/Facebook/InstantArticles/Elements/Interactive.php
+++ b/src/Facebook/InstantArticles/Elements/Interactive.php
@@ -199,10 +199,6 @@ class Interactive extends ElementWithHTML implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $figure = $document->createElement('figure');
         $iframe = $document->createElement('iframe');
 
@@ -210,9 +206,7 @@ class Interactive extends ElementWithHTML implements ChildrenContainer
         $figure->setAttribute('class', 'op-interactive');
 
         // Caption markup optional
-        if ($this->caption) {
-            $figure->appendChild($this->caption->toDOMElement($document));
-        }
+        Element::appendChild($figure, $this->caption, $document);
 
         if ($this->source) {
             $iframe->setAttribute('src', $this->source);

--- a/src/Facebook/InstantArticles/Elements/Italic.php
+++ b/src/Facebook/InstantArticles/Elements/Italic.php
@@ -38,10 +38,6 @@ class Italic extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $italic = $document->createElement('i');
 
         $italic->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/LineBreak.php
+++ b/src/Facebook/InstantArticles/Elements/LineBreak.php
@@ -45,10 +45,6 @@ class LineBreak extends FormattedText
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $br = $document->createElement('br');
 
         return $br;

--- a/src/Facebook/InstantArticles/Elements/ListElement.php
+++ b/src/Facebook/InstantArticles/Elements/ListElement.php
@@ -158,10 +158,6 @@ class ListElement extends Element implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         if ($this->isOrdered) {
             $element = $document->createElement('ol');
         } else {
@@ -170,9 +166,7 @@ class ListElement extends Element implements ChildrenContainer
 
         if ($this->items) {
             foreach ($this->items as $item) {
-                if ($item) {
-                    $element->appendChild($item->toDOMElement($document));
-                }
+                Element::appendChild($element, $item, $document);
             }
         }
 

--- a/src/Facebook/InstantArticles/Elements/ListItem.php
+++ b/src/Facebook/InstantArticles/Elements/ListItem.php
@@ -41,10 +41,6 @@ class ListItem extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $list_item = $document->createElement('li');
 
         $list_item->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Map.php
+++ b/src/Facebook/InstantArticles/Elements/Map.php
@@ -151,27 +151,17 @@ class Map extends Audible
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('figure');
         $element->setAttribute('class', 'op-map');
 
         // Geotag markup REQUIRED
-        if ($this->geoTag) {
-            $element->appendChild($this->geoTag->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->geoTag, $document);
 
         // Caption markup optional
-        if ($this->caption) {
-            $element->appendChild($this->caption->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->caption, $document);
 
         // Audio markup optional
-        if ($this->audio) {
-            $element->appendChild($this->audio->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->audio, $document);
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/Paragraph.php
+++ b/src/Facebook/InstantArticles/Elements/Paragraph.php
@@ -47,10 +47,6 @@ class Paragraph extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $paragraph = $document->createElement('p');
 
         $paragraph->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Pullquote.php
+++ b/src/Facebook/InstantArticles/Elements/Pullquote.php
@@ -84,18 +84,12 @@ class Pullquote extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('aside');
 
         $element->appendChild($this->textToDOMDocumentFragment($document));
 
         // Attribution Citation
-        if ($this->attribution) {
-            $element->appendChild($this->attribution->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->attribution, $document);
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/RelatedArticles.php
+++ b/src/Facebook/InstantArticles/Elements/RelatedArticles.php
@@ -112,10 +112,6 @@ class RelatedArticles extends Element implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('ul');
         $element->setAttribute('class', 'op-related-articles');
         if ($this->title) {
@@ -124,7 +120,7 @@ class RelatedArticles extends Element implements ChildrenContainer
 
         if ($this->items) {
             foreach ($this->items as $item) {
-                $element->appendChild($item->toDOMElement($document));
+                Element::appendChild($element, $item, $document);
             }
         }
 

--- a/src/Facebook/InstantArticles/Elements/RelatedItem.php
+++ b/src/Facebook/InstantArticles/Elements/RelatedItem.php
@@ -108,17 +108,15 @@ class RelatedItem extends Element
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('li');
         if ($this->sponsored) {
             $element->setAttribute('data-sponsored', 'true');
         }
-        $element->appendChild(
-            Anchor::create()->withHref($this->url)->toDOMElement($document)
-        );
+        if ($this->url) {
+            $anchor = $document->createElement('a');
+            $anchor->setAttribute('href', $this->url);
+            $element->appendChild($anchor);
+        }
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/Slideshow.php
+++ b/src/Facebook/InstantArticles/Elements/Slideshow.php
@@ -202,25 +202,18 @@ class Slideshow extends Audible
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('figure');
         $element->setAttribute('class', 'op-slideshow');
 
         // URL markup required
         if ($this->article_images) {
             foreach ($this->article_images as $article_image) {
-                $article_image_element = $article_image->toDOMElement($document);
-                $element->appendChild($article_image_element);
+                Element::appendChild($element, $article_image, $document);
             }
         }
 
         // Caption markup optional
-        if ($this->caption) {
-            $element->appendChild($this->caption->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->caption, $document);
 
         // Geotag markup optional
         if ($this->geotag) {
@@ -232,9 +225,7 @@ class Slideshow extends Audible
         }
 
         // Audio markup optional
-        if ($this->audio) {
-            $element->appendChild($this->audio->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->audio, $document);
 
         return $element;
     }

--- a/src/Facebook/InstantArticles/Elements/Small.php
+++ b/src/Facebook/InstantArticles/Elements/Small.php
@@ -40,10 +40,6 @@ class Small extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $small = $document->createElement('small');
 
         $small->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Span.php
+++ b/src/Facebook/InstantArticles/Elements/Span.php
@@ -40,10 +40,6 @@ class Span extends TextContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $span = $document->createElement('span');
 
         $span->appendChild($this->textToDOMDocumentFragment($document));

--- a/src/Facebook/InstantArticles/Elements/Sponsor.php
+++ b/src/Facebook/InstantArticles/Elements/Sponsor.php
@@ -74,10 +74,6 @@ class Sponsor extends Element
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('ul');
         $element->setAttribute('class', 'op-sponsors');
 

--- a/src/Facebook/InstantArticles/Elements/TextContainer.php
+++ b/src/Facebook/InstantArticles/Elements/TextContainer.php
@@ -77,7 +77,7 @@ abstract class TextContainer extends Element implements ChildrenContainer
                 $text = $document->createTextNode($content);
                 $fragment->appendChild($text);
             } else {
-                $fragment->appendChild($content->toDOMElement($document));
+                Element::appendChild($fragment, $content, $document);
             }
         }
 

--- a/src/Facebook/InstantArticles/Elements/Time.php
+++ b/src/Facebook/InstantArticles/Elements/Time.php
@@ -155,11 +155,7 @@ class Time extends Element
         if (!$document) {
             $document = new \DOMDocument();
         }
-
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
+        
         $datetime = $this->date->format('c');
         $date = $this->date->format('F jS, g:ia');
 

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -483,10 +483,6 @@ class Video extends Element implements ChildrenContainer
             $document = new \DOMDocument();
         }
 
-        if (!$this->isValid()) {
-            return $this->emptyElement($document);
-        }
-
         $element = $document->createElement('figure');
 
         // Presentation
@@ -535,14 +531,10 @@ class Video extends Element implements ChildrenContainer
         }
 
         // Caption markup optional
-        if ($this->caption) {
-            $element->appendChild($this->caption->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->caption, $document);
 
         // Geotag markup optional
-        if ($this->geoTag) {
-            $element->appendChild($this->geoTag->toDOMElement($document));
-        }
+        Element::appendChild($element, $this->geoTag, $document);
 
         // Attribution Citation
         if ($this->attribution) {

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-ia.xml
@@ -236,6 +236,10 @@
       <figure><img src="http://example.com/credit-image.jpg"/></figure>
       <figure><img src="http://example.com/image-inside-p.jpg"/></figure>
       <figure><img src="http://example.com/image-inside-p-a.jpg"/></figure>
+      <ul class="op-related-articles" title="Related Articles">
+        <li><a href="http://example.com/related-1.html"></a></li>
+        <li><a href="http://example.com/related-2.html"></a></li>
+      </ul>    
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/custom-html-rules.json
@@ -711,6 +711,28 @@
                 "attribute": "height"
             }
         }
+    },
+    {
+      "class" : "RelatedArticlesRule",
+      "selector" : "ul.related-articles",
+      "properties" : {
+        "related.title" : {
+          "type" : "string",
+          "selector" : "ul.related-articles",
+          "attribute" : "title"
+        }
+      }
+    },
+    {
+      "class" : "RelatedItemRule",
+      "selector" : "li",
+      "properties" : {
+        "related.url" : {
+          "type" : "string",
+          "selector" : "a",
+          "attribute" : "href"
+        }
+      }
     }
   ]
 }

--- a/tests/Facebook/InstantArticles/Transformer/custom.html
+++ b/tests/Facebook/InstantArticles/Transformer/custom.html
@@ -263,5 +263,9 @@
             <img src="http://example.com/image-inside-p-a.jpg"/>
         </a>
     </p>
+    <ul class="related-articles" title="Related Articles">
+        <li><a href="http://example.com/related-1.html"></a></li>
+        <li><a href="http://example.com/related-2.html"></a></li>
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
… / refactored elements to not return an empty element when it's invalid

This PR

* fixes Anchor isValid method to check also for the content
* removed the use of Anchor class in RelatedItem in favor of using a simple 'a' element.
* Refactors the elements in order to avoid returning an empty element when the element is invalid which is not necessary.
