### PR TITLE
Return on null node

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -277,6 +277,7 @@ class Transformer
                 'some nested transform operation and fix the selector.',
                 $e->getTraceAsString()
             );
+            return $context;
         }
         $current_context = $context;
         if ($node->hasChildNodes()) {


### PR DESCRIPTION
This PR

* [x] Fixes processing empty nodes.

When the transformer finds a null node, it should continue processing.