### PR TITLE
Added support for new dateTextContent attr in GlobalRule

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Getters/DateGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/DateGetter.php
@@ -50,8 +50,8 @@ class DateGetter extends StringGetter
         if (!empty($elements) && $elements->item(0)) {
             $element = $elements->item(0);
 
-            if ($this->attribute && $this->attribute != 'dateTextContent') {
-                return \DateTime::createFromFormat($this->format, $element->getAttribute($this->attribute));
+            if ($this->attribute) {
+                return \DateTime::createFromFormat('!'.$this->format, $element->getAttribute($this->attribute));
             }
             return \DateTime::createFromFormat('!'.$this->format, trim($element->textContent));
         }

--- a/src/Facebook/InstantArticles/Transformer/Getters/DateGetter.php
+++ b/src/Facebook/InstantArticles/Transformer/Getters/DateGetter.php
@@ -50,10 +50,10 @@ class DateGetter extends StringGetter
         if (!empty($elements) && $elements->item(0)) {
             $element = $elements->item(0);
 
-            if ($this->attribute) {
+            if ($this->attribute && $this->attribute != 'dateTextContent') {
                 return \DateTime::createFromFormat($this->format, $element->getAttribute($this->attribute));
             }
-            return \DateTime::createFromFormat($this->format, $element->textContent);
+            return \DateTime::createFromFormat('!'.$this->format, trim($element->textContent));
         }
         return null;
     }

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/GlobalTransformerTest.php
@@ -39,4 +39,31 @@ class GlobalTransformerTest extends BaseHtmlTestCase
         $this->assertEqualsHtml($expected, $result);
         $this->assertCount(0, $transformer->getWarnings());
     }
+
+    public function testSelfTransformerContentWithTestDate()
+    {
+        date_default_timezone_set('UTC');
+
+        $json_file = file_get_contents(__DIR__ . '/global-rules-with-text-date.json');
+
+        $instant_article = InstantArticle::create();
+        $transformer = new Transformer();
+        $transformer->loadRules($json_file);
+
+        $html_file = file_get_contents(__DIR__ . '/global-with-text-date.html');
+
+        libxml_use_internal_errors(true);
+        $document = new \DOMDocument();
+        $document->loadHTML($html_file);
+        libxml_use_internal_errors(false);
+
+        $transformer->transform($instant_article, $document);
+        $instant_article->addMetaProperty('op:generator:version', '1.0.0');
+        $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
+        $result = $instant_article->render('', true)."\n";
+        $expected = file_get_contents(__DIR__ . '/global-ia-with-text-date.html');
+
+        $this->assertEqualsHtml($expected, $result);
+        $this->assertCount(0, $transformer->getWarnings());
+    }
 }

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-ia-with-text-date.html
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-ia-with-text-date.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <link rel="canonical" href="http://domain.com/article_full_example.html"/>
+    <meta charset="utf-8"/>
+    <meta property="op:generator" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:version" content="1.0.0"/>
+    <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
+    <meta property="op:generator:transformer:version" content="1.0.0"/>
+    <meta property="op:markup_version" content="v1.0"/>
+  </head>
+  <body>
+    <article>
+      <header>
+        <figure>
+          <img src="http://domain.com/header-image-body.png"/>
+        </figure>
+        <h1>The <b>article</b> title</h1>
+        <time class="op-published" datetime="2018-02-05T00:00:00+00:00">February 5th, 12:00am</time>
+        <address><a href="http://facebook.com/author" rel="facebook" title="Journalist">Author Name</a>Some author description</address>
+      </header>
+      <p>Lorem <b>ipsum</b> dolor sit amet.</p>
+      <figure>
+        <img src="http://domain.com/image-body.png"/>
+        <figcaption>The caption for image.</figcaption>
+      </figure>
+    </article>
+  </body>
+</html>

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules-with-text-date.json
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules-with-text-date.json
@@ -1,0 +1,221 @@
+{
+    "rules":[
+        {
+            "class":"TextNodeRule"
+        },
+        {
+            "class":"IgnoreRule",
+            "selector":"div.author"
+        },
+        {
+            "class":"GlobalRule",
+            "selector":"html",
+            "properties":{
+                "article.title":{
+                    "type":"element",
+                    "selector":"div.header h1"
+                },
+                "author.url":{
+                    "type":"string",
+                    "selector":"div.author a",
+                    "attribute":"href"
+                },
+                "author.name":{
+                    "type":"string",
+                    "selector":"div.author a"
+                },
+                "author.role_contribution" : {
+                    "type" : "string",
+                    "selector" : "div.author a",
+                    "attribute": "title"
+                },
+                "author.description" : {
+                    "type" : "string",
+                    "selector" : "div.author span"
+                },
+                "article.canonical": {
+                    "type" : "string",
+                    "selector": "head meta",
+                    "attribute": "content"
+                },
+                "article.publish": {
+                    "selector": "div.date",
+                    "type": "date",
+                    "attribute": "dateTextContent",
+                    "format": "M j, Y"
+                },
+                "article.body":{
+                    "selector":"article",
+                    "type":"element"
+                },
+                "image.url":{
+                    "selector":"div.hero-image img",
+                    "type":"string",
+                    "attribute":"src"
+                }
+            }
+        },
+        {
+            "class":"PassThroughRule",
+            "selector":"head, script, body"
+        },
+        {
+            "class":"ItalicRule",
+            "selector":"i"
+        },
+        {
+            "class":"BoldRule",
+            "selector":"b"
+        },
+        {
+            "class":"ParagraphRule",
+            "selector":"p"
+        },
+        {
+            "class":"HeaderTitleRule",
+            "selector":"h1"
+        },
+        {
+            "class":"HeaderSubTitleRule",
+            "selector":"h2"
+        },
+        {
+            "class":"HeaderRule",
+            "selector":"div.header"
+        },
+        {
+            "class":"AuthorRule",
+            "selector":"span.author",
+            "properties":{
+                "author.name":{
+                    "type":"string",
+                    "selector":"span"
+                }
+            }
+        },
+        {
+            "class":"CaptionRule",
+            "selector":"div.image-caption"
+        },
+        {
+            "class":"CaptionRule",
+            "selector":"span.caption",
+            "properties":{
+                "caption.default":{
+                    "type":"string",
+                    "selector":"img",
+                    "attribute":"alt"
+                }
+            }
+        },
+        {
+            "class":"ImageRule",
+            "selector":"div.image",
+            "properties":{
+                "image.url":{
+                    "type":"string",
+                    "selector":"img",
+                    "attribute":"src"
+                }
+            }
+        },
+        {
+            "class":"ImageRule",
+            "selector":"div.prefix",
+            "properties":{
+                "image.url":{
+                    "type":"string",
+                    "selector":"img",
+                    "attribute":"src",
+                    "prefix":"http:"
+                },
+                "image.caption":{
+                    "type":"element",
+                    "selector":"div.image-caption"
+                }
+            }
+        },
+        {
+            "class":"ImageRule",
+            "selector":"div.suffix",
+            "properties":{
+                "image.url":{
+                    "type":"string",
+                    "selector":"img",
+                    "attribute":"src",
+                    "suffix":"?suffix=yes"
+                },
+                "image.caption":{
+                    "type":"element",
+                    "selector":"div.image-caption"
+                }
+            }
+        },
+        {
+            "class":"ImageRule",
+            "selector":"div.prefixsuffix",
+            "properties":{
+                "image.url":{
+                    "type":"string",
+                    "selector":"img",
+                    "attribute":"src",
+                    "prefix":"http:",
+                    "suffix":"?suffix=yes"
+                },
+                "image.caption":{
+                    "type":"element",
+                    "selector":"div.image-caption"
+                }
+            }
+        },
+        {
+            "class":"IgnoreRule",
+            "selector":"div.hero-image"
+        },
+        {
+            "class":"SocialEmbedRule",
+            "selector":"div.embed",
+            "properties":{
+                "socialembed.iframe":{
+                    "type":"children",
+                    "selector":"*"
+                }
+            }
+        },
+        {
+            "class":"FooterRule",
+            "selector":"footer"
+        },
+        {
+            "class":"RelatedArticlesRule",
+            "selector":"ul.op-related-articles",
+            "properties":{
+                "related.title":{
+                    "type":"exists",
+                    "selector":"ul.op-related-articles",
+                    "attribute":"title"
+                }
+            }
+        },
+        {
+            "class":"FooterRelatedArticlesRule",
+            "selector":"ul.op-related-articles"
+        },
+        {
+            "class":"RelatedItemRule",
+            "selector":"li",
+            "properties":{
+                "related.sponsored":{
+                    "type":"exists",
+                    "selector":"li",
+                    "attribute":"data-sponsored"
+                },
+                "related.url":{
+                    "type":"string",
+                    "selector":"a",
+                    "attribute":"href"
+                }
+            }
+        }
+    ]
+}

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules-with-text-date.json
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-rules-with-text-date.json
@@ -41,7 +41,6 @@
                 "article.publish": {
                     "selector": "div.date",
                     "type": "date",
-                    "attribute": "dateTextContent",
                     "format": "M j, Y"
                 },
                 "article.body":{

--- a/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-with-text-date.html
+++ b/tests/Facebook/InstantArticles/Transformer/GlobalHtml/global-with-text-date.html
@@ -1,0 +1,26 @@
+<html>
+    <head>
+        <script type="text/javascript" href="http://domain.com/javascript.js" />
+        <meta property="og:url" content="http://domain.com/article_full_example.html" />
+    </head>
+    <body>
+        <div class="header">
+            <h1>The <b>article</b> title</h1>
+            <div class="date">Feb 5, 2018</div>
+        </div>
+        <article>
+            <p>Lorem <b>ipsum</b> dolor sit amet.</p>
+            <div class="image">
+                <img src="http://domain.com/image-body.png"/>
+                <span class="caption">The caption for image.</span>
+            </div>
+            <div class="hero-image">
+                <img src="http://domain.com/header-image-body.png"/>
+            </div>
+            <div class="author">
+                By: <a href="http://facebook.com/author" title="Journalist">Author Name</a>
+                <span>Some author description</span>
+            </div>
+        </article>
+    </body>
+</html>

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -92,8 +92,6 @@ class TransformerTest extends BaseHTMLTestCase
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";
 
-        //var_dump($result);
-        // print_r($warnings);
         $this->assertEqualsHtml($html_file, $result);
     }
 


### PR DESCRIPTION
This PR

* adds support for a new attribute dateTextContent used in GlobalRule for dates that are in the content side and not in the datetime attribute.
