### PR TITLE
Configuration for ADS, Analytics and style on Transformation

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Settings/AdSettings.php
+++ b/src/Facebook/InstantArticles/Transformer/Settings/AdSettings.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Settings;
+
+use Facebook\InstantArticles\Validators\Type;
+
+class AdSettings
+{
+    /**
+     * @var string $audienceNetworkPlacementId AN representational ID
+     */
+    private $audienceNetworkPlacementId;
+
+    /**
+     * @var string $rawHTML The raw HTML content for ADS to be inserted into Instant Articles
+     */
+    private $rawHTML;
+
+    public function __construct($audienceNetworkPlacementId = "", $rawHTML = "")
+    {
+        if (Type::enforce($audienceNetworkPlacementId, Type::STRING) &&
+            !Type::isTextEmpty($audienceNetworkPlacementId)) {
+            $this->audienceNetworkPlacementId = $audienceNetworkPlacementId;
+        }
+        if (Type::enforce($rawHTML, Type::STRING) &&
+            !Type::isTextEmpty($rawHTML)) {
+            $this->rawHTML = $rawHTML;
+        }
+    }
+
+    /**
+     * @return string Returns the previous set raw HTML content;
+     */
+    public function getRawHTML()
+    {
+        return $this->rawHTML;
+    }
+
+    /**
+     * @return string Returns the previous set AN ID.
+     */
+    public function getAudienceNetworkPlacementId()
+    {
+        return $this->audienceNetworkPlacementId;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Settings/AdSettings.php
+++ b/src/Facebook/InstantArticles/Transformer/Settings/AdSettings.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Settings;
 
 use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Elements\Ad;
 
 class AdSettings
 {
@@ -48,5 +49,29 @@ class AdSettings
     public function getAudienceNetworkPlacementId()
     {
         return $this->audienceNetworkPlacementId;
+    }
+
+    public function getAdElement()
+    {
+        $ad = null;
+
+        if (!Type::isTextEmpty($this->getAudienceNetworkPlacementId()) ||
+            (!Type::isTextEmpty($this->getRawHTML()))) {
+
+            $ad = Ad::create();
+            if (!Type::isTextEmpty($this->getAudienceNetworkPlacementId())) {
+                $ad->withSource(
+                    'https://www.facebook.com/adnw_request?placement='.
+                    $this->getAudienceNetworkPlacementId()
+                );
+            }
+            if (!Type::isTextEmpty($this->getRawHTML())) {
+                $ad->withHTML(
+                    $this->getRawHTML()
+                );
+            }
+        }
+
+        return $ad;
     }
 }

--- a/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
+++ b/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\InstantArticles\Transformer\Settings;
+
+use Facebook\InstantArticles\Validators\Type;
+
+class AnalyticsSettings
+{
+    /**
+     * @var string $fbPixelId Facebook pixel representational ID
+     */
+    private $fbPixelId;
+
+    /**
+     * @var string $rawHTML The raw HTML content for ADS to be inserted into Instant Articles
+     */
+    private $rawHTML;
+
+    public function __construct($fbPixelId = "", $rawHTML = "")
+    {
+        if (Type::enforce($fbPixelId, Type::STRING) &&
+            !Type::isTextEmpty($fbPixelId)) {
+            $this->fbPixelId = $fbPixelId;
+        }
+        if (Type::enforce($rawHTML, Type::STRING) &&
+            !Type::isTextEmpty($rawHTML)) {
+            $this->rawHTML = $rawHTML;
+        }
+    }
+
+    /**
+     * @return string Returns the previous set raw HTML content;
+     */
+    public function getRawHTML()
+    {
+        return $this->rawHTML;
+    }
+
+    /**
+     * @return string Returns the previous set AN ID.
+     */
+    public function getFbPixelId()
+    {
+        return $this->fbPixelId;
+    }
+
+    public function getFbPixelScript()
+    {
+        $pixelCode = "";
+        if ($this->fbPixelId && !Type::isTextEmpty($this->fbPixelId)) {
+            $pixelCode = $pixelCode.
+                "<!-- Facebook Pixel Code --> ".
+                "<script> ".
+                  "!function(f,b,e,v,n,t,s) ".
+                  "{if(f.fbq)return;n=f.fbq=function(){n.callMethod? ".
+                  "n.callMethod.apply(n,arguments):n.queue.push(arguments)}; ".
+                  "if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0'; ".
+                  "n.queue=[];t=b.createElement(e);t.async=!0; ".
+                  "t.src=v;s=b.getElementsByTagName(e)[0]; ".
+                  "s.parentNode.insertBefore(t,s)}(window, document,'script', ".
+                  "'https://connect.facebook.net/en_US/fbevents.js'); ".
+                  "fbq('init', '$this->fbPixelId'); ".
+                  "fbq('track', 'PageView'); ".
+                "</script> ".
+                "<noscript><img height=\"1\" width=\"1\" style=\"display:none\" ".
+                  "src=\"https://www.facebook.com/tr?ev=PageView&noscript=1&id=$this->fbPixelId\" ".
+                "/></noscript> ".
+                "<!-- End Facebook Pixel Code -->";
+        }
+
+        if ($this->rawHTML && !Type::isTextEmpty($this->rawHTML)) {
+            $pixelCode = $pixelCode." ".$this->rawHTML;
+        }
+
+        return $pixelCode;
+    }
+}

--- a/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
+++ b/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
@@ -9,6 +9,7 @@
 namespace Facebook\InstantArticles\Transformer\Settings;
 
 use Facebook\InstantArticles\Validators\Type;
+use Facebook\InstantArticles\Elements\Analytics;
 
 class AnalyticsSettings
 {
@@ -79,5 +80,15 @@ class AnalyticsSettings
         }
 
         return $pixelCode;
+    }
+
+    public function getAnalyticsElement()
+    {
+        $analytics = null;
+        if (!Type::isTextEmpty($this->getFbPixelScript())) {
+            $analytics = Analytics::create();
+            $analytics->withHTML($this->getFbPixelScript());
+        }
+        return $analytics;
     }
 }

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -12,8 +12,10 @@ use Facebook\InstantArticles\Transformer\Warnings\UnrecognizedElement;
 use Facebook\InstantArticles\Transformer\Logs\TransformerLog;
 use Facebook\InstantArticles\Transformer\Rules\Rule;
 use Facebook\InstantArticles\Transformer\Settings\AdSettings;
+use Facebook\InstantArticles\Transformer\Settings\AnalyticsSettings;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Ad;
+use Facebook\InstantArticles\Elements\Analytics;
 use Facebook\InstantArticles\Validators\Type;
 use Facebook\InstantArticles\Validators\InstantArticleValidator;
 
@@ -63,6 +65,11 @@ class Transformer
      * @var AdSettings The content settings for ads on this transformation cycle.
      */
     private $adsSettings;
+
+    /**
+     * @var AnalyticsSettings The content settings for analytics on this transformation cycle.
+     */
+    private $analyticsSettings;
 
     /**
      * Flag attribute added to elements processed by a getter, so they
@@ -402,7 +409,7 @@ class Transformer
 
         // Treats the Analyticds configuration
         if ($configuration && isset($configuration['analytics'])) {
-            //$this->loadAnalyicsConfiguration($configuration['analytics']);
+            $this->loadAnalyicsConfiguration($configuration['analytics']);
         }
 
         // Treats the Style configuration
@@ -518,12 +525,18 @@ class Transformer
                     $this->adsSettings->getAudienceNetworkPlacementId()
                 );
             }
-            if (!Type::isTextEmpty($this->adsSettings->getRawHtml())) {
+            if (!Type::isTextEmpty($this->adsSettings->getRawHTML())) {
                 $ad->withHTML(
                     $this->adsSettings->getRawHTML()
                 );
             }
             $instantArticle->getHeader()->addAd($ad);
+        }
+
+        if ($this->analyticsSettings) {
+            $analytics = Analytics::create();
+            $analytics->withHTML($this->analyticsSettings->getFbPixelScript());
+            $instantArticle->addChild($analytics);
         }
 
         return $instantArticle;
@@ -534,6 +547,14 @@ class Transformer
         $this->adsSettings = new AdSettings(
             $adsSettings['audience_network_placement_id'],
             $adsSettings['raw_html']
+        );
+    }
+
+    public function loadAnalyicsConfiguration($analyticsSettings)
+    {
+        $this->analyticsSettings = new AnalyticsSettings(
+            $analyticsSettings['fb_pixel_id'],
+            $analyticsSettings['raw_html']
         );
     }
 }

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -518,25 +518,17 @@ class Transformer
         }
 
         if ($this->adsSettings) {
-            $ad = Ad::create();
-            if (!Type::isTextEmpty($this->adsSettings->getAudienceNetworkPlacementId())) {
-                $ad->withSource(
-                    'https://www.facebook.com/adnw_request?placement='.
-                    $this->adsSettings->getAudienceNetworkPlacementId()
-                );
+            $ad = $this->adsSettings->getAdElement();
+            if ($ad) {
+                $instantArticle->getHeader()->addAd($ad);
             }
-            if (!Type::isTextEmpty($this->adsSettings->getRawHTML())) {
-                $ad->withHTML(
-                    $this->adsSettings->getRawHTML()
-                );
-            }
-            $instantArticle->getHeader()->addAd($ad);
         }
 
         if ($this->analyticsSettings) {
-            $analytics = Analytics::create();
-            $analytics->withHTML($this->analyticsSettings->getFbPixelScript());
-            $instantArticle->addChild($analytics);
+            $analytics = $this->analyticsSettings->getAnalyticsElement();
+            if ($analytics) {
+                $instantArticle->addChild($analytics);
+            }
         }
 
         return $instantArticle;

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -7,6 +7,7 @@
     <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
     <meta property="op:generator:transformer:version" content="1.0.0"/>
     <meta property="op:markup_version" content="v1.0"/>
+    <meta property="fb:article_style" content="mydefaultstyle"/>
   </head>
   <body>
     <article>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -7,12 +7,19 @@
     <meta property="op:generator:transformer" content="facebook-instant-articles-sdk-php"/>
     <meta property="op:generator:transformer:version" content="1.0.0"/>
     <meta property="op:markup_version" content="v1.0"/>
+    <meta property="fb:use_automatic_ad_placement" content="enable=true ad_density=default"/>
     <meta property="fb:article_style" content="mydefaultstyle"/>
   </head>
   <body>
     <article>
       <header>
         <h1>The article title</h1>
+        <figure class="op-ad">
+          <iframe src="https://www.facebook.com/adnw_request?placement=1234">
+            <script>alert('hello world!');</script>
+            <div class='block'></div>
+          </iframe>
+        </figure>
       </header>
       <p>Lorem <b>ipsum</b> dolor sit <b>amet</b>.</p>
       <figure>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -26,6 +26,16 @@
         <img src="http://domain.com/image-body.png"/>
         <figcaption>Photographer</figcaption>
       </figure>
+      <figure class="op-tracker">
+        <iframe>
+          <!-- Facebook Pixel Code -->
+          <script>
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)}; if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0'; n.queue=[];t=b.createElement(e);t.async=!0; t.src=v;s=b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s)}(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js'); fbq('init', '4321'); fbq('track', 'PageView'); </script>
+          <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?ev=PageView&noscript=1&id=4321" /></noscript>
+          <!-- End Facebook Pixel Code -->
+          <script>alert('hello world!');</script>
+          <div class='block'></div></iframe></figure>
     </article>
   </body>
 </html>

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -1,4 +1,5 @@
 {
+    "style_name" : "mydefaultstyle",
     "rules" :
         [
             {

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -1,5 +1,9 @@
 {
     "style_name" : "mydefaultstyle",
+    "ads" : {
+        "audience_network_placement_id": "1234",
+        "raw_html": "<script>alert('hello world!');</script><div class='block'></div>"
+    },
     "rules" :
         [
             {

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-rules.json
@@ -4,6 +4,10 @@
         "audience_network_placement_id": "1234",
         "raw_html": "<script>alert('hello world!');</script><div class='block'></div>"
     },
+    "analytics" : {
+        "fb_pixel_id": "4321",
+        "raw_html": "<script>alert('hello world!');</script><div class='block'></div>"
+    },
     "rules" :
         [
             {


### PR DESCRIPTION
This adds a new defaulStyleName to the transformer instance, so this way we can set this up into the InstantArticle generated markup after transformation occurs.

- [x] Added defaultStyleName to Transformer
- [x] Added test case to cover this new defaultStyleName
- [x] Added get/set for the styleName on Transformer

- [x] Add object structure for ADS on Transformer
- [x] Add test case to cover ADS on Transformer
- [x] Add get/set for the ADS on Transformer

- [x] Add object structure for Analytics on Transformer
- [x] Add test case to cover Analytics on Transformer
- [x] Add get/set for the Analytics on Transformer
