### PR TITLE
[WIP] convert html5-entities like &comma;

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Element.php
+++ b/src/Facebook/InstantArticles/Elements/Element.php
@@ -42,7 +42,6 @@ abstract class Element
         } else {
             $rendered = '';
         }
-
         // We can't currently use DOMDocument::saveHTML, because it doesn't produce proper HTML5 markup, so we have to strip CDATA enclosures
         // TODO Consider replacing this workaround with a parent class for elements that will be rendered and in this class use the `srcdoc` attribute to output the (escaped) markup
         $rendered = preg_replace('/<!\[CDATA\[(.*?)\]\]>/is', '$1', $rendered);
@@ -67,6 +66,7 @@ abstract class Element
         // TODO (timjacobi): can we make this more elegant?
         $rendered = preg_replace('/&amp;([^(\s|;)]*;)/', '&$1', $rendered);
         $rendered = preg_replace_callback('/(src|href|url|link)="([^"]*)"/is', [__CLASS__, 'urlDecoder'], $rendered);
+        $rendered = html_entity_decode($rendered, ENT_QUOTES | ENT_HTML5);
 
         return $rendered;
     }

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
@@ -38,7 +38,7 @@
       <p>パラグラフ内のテキストのテストです。</p>
       <figure data-feedback="fb:likes">
         <img src="http://mydomain.com/path/to/img.jpg"/>
-        <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
+        <audio title="オーディオタイトル" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
@@ -59,7 +59,7 @@
             }
           }
         </script>
-        <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
+        <audio title="オーディオタイトル" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
@@ -79,7 +79,7 @@
           <img src="https://jpeg.org/images/jpegls-home3.jpg"/>
         </figure>
         <figcaption><h1>イメージ名</h1>テキストノード<cite>イメージキャプション</cite></figcaption>
-        <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
+        <audio title="オーディオタイトル" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>


### PR DESCRIPTION
I'm looking to fix https://github.com/Automattic/facebook-instant-articles-wp/issues/881
There are a couple of tests failing which makes me wonder
* Why do these tests expect entities not to be converted to their characters?
* What should the output be to IA, entities (&period;) or their characters (.)?
* "some fragments are written as html entities even after transformed so normalize all strings to html entities and compare them." in the tests worries me. Should we not try to convert all entities?