### PR TITLE
Update IA Pixel code to include ViewContent event

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
+++ b/src/Facebook/InstantArticles/Transformer/Settings/AnalyticsSettings.php
@@ -68,10 +68,11 @@ class AnalyticsSettings
                   "'https://connect.facebook.net/en_US/fbevents.js'); ".
                   "fbq('init', '$this->fbPixelId'); ".
                   "fbq('track', 'PageView'); ".
-                "</script> ".
-                "<noscript><img height=\"1\" width=\"1\" style=\"display:none\" ".
-                  "src=\"https://www.facebook.com/tr?ev=PageView&noscript=1&id=$this->fbPixelId\" ".
-                "/></noscript> ".
+                  "fbq('track', 'ViewContent', {".
+                    "title: ia_document.title, ".
+                    "platform: 'InstantArticles'".
+                  "});".
+                "</script>".
                 "<!-- End Facebook Pixel Code -->";
         }
 

--- a/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
+++ b/tests/Facebook/InstantArticles/Transformer/Example/simple-ia.html
@@ -29,8 +29,7 @@
           <!-- Facebook Pixel Code -->
           <script>
           !function(f,b,e,v,n,t,s)
-          {if(f.fbq)return;n=f.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)}; if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0'; n.queue=[];t=b.createElement(e);t.async=!0; t.src=v;s=b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s)}(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js'); fbq('init', '4321'); fbq('track', 'PageView'); </script>
-          <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?ev=PageView&noscript=1&id=4321" /></noscript>
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)}; if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0'; n.queue=[];t=b.createElement(e);t.async=!0; t.src=v;s=b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s)}(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js'); fbq('init', '4321'); fbq('track', 'PageView'); fbq('track', 'ViewContent', {title: ia_document.title, platform: 'InstantArticles'});</script>
           <!-- End Facebook Pixel Code -->
           <script>alert('hello world!');</script>
           <div class='block'></div></iframe></figure>


### PR DESCRIPTION
This PR updates the javascript that we add as part of the Facebook Pixel analytics element:

* [x] Adds the ViewContent element with a parameter to flag that the platform is Instant Articles
* [x] Removes the unnecessary `noscript` block

I verified that the pixel events look good from Events Manager:

![image](https://user-images.githubusercontent.com/18663703/48283704-452b6a80-e42b-11e8-9a45-0702ca399465.png)
