### PR TITLE
Deprecation of feature to add comments/share/like to individual media content within articles

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Image.php
+++ b/src/Facebook/InstantArticles/Elements/Image.php
@@ -41,16 +41,6 @@ class Image extends Audible
     const NON_INTERACTIVE = 'non-interactive';
 
     /**
-     * @var boolean marks if any created image will have likes enabled by default
-     */
-    public static $defaultLikeEnabled = false;
-
-    /**
-     * @var boolean marks if any created image will have comments enabled by default
-     */
-    public static $defaultCommentEnabled = false;
-
-    /**
      * @var Caption The caption for Image
      */
     private $caption;
@@ -60,16 +50,6 @@ class Image extends Audible
      * on the article
      */
     private $url;
-
-    /**
-     * @var bool Tells if like is enabled. Default: false
-     */
-    private $isLikeEnabled;
-
-    /**
-     * @var bool Tells if comments are enabled. Default: false
-     */
-    private $isCommentsEnabled;
 
     /**
      * @var string The picture size for the video.
@@ -96,8 +76,6 @@ class Image extends Audible
      */
     private function __construct()
     {
-        $this->isLikeEnabled = self::$defaultLikeEnabled;
-        $this->isCommentsEnabled = self::$defaultCommentEnabled;
     }
 
     /**
@@ -169,41 +147,37 @@ class Image extends Audible
 
     /**
      * Makes like enabled for this image.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function enableLike()
     {
-        $this->isLikeEnabled = true;
-
         return $this;
     }
 
     /**
      * Makes like disabled for this image.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function disableLike()
     {
-        $this->isLikeEnabled = false;
-
         return $this;
     }
 
     /**
      * Makes comments enabled for this image.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function enableComments()
     {
-        $this->isCommentsEnabled = true;
-
         return $this;
     }
 
     /**
      * Makes comments disabled for this image.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function disableComments()
     {
-        $this->isCommentsEnabled = false;
-
         return $this;
     }
 
@@ -257,18 +231,20 @@ class Image extends Audible
 
     /**
      * @return boolean tells if the like button is enabled
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function isLikeEnabled()
     {
-        return $this->isLikeEnabled;
+        return false;
     }
 
     /**
      * @return boolean tells if the comments widget is enabled
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function isCommentsEnabled()
     {
-        return $this->isCommentsEnabled;
+        return false;
     }
 
     /**
@@ -313,17 +289,6 @@ class Image extends Audible
         }
 
         $element = $document->createElement('figure');
-
-        // Like/comments markup optional
-        if ($this->isLikeEnabled || $this->isCommentsEnabled) {
-            if ($this->isLikeEnabled && $this->isCommentsEnabled) {
-                $element->setAttribute('data-feedback', 'fb:likes,fb:comments');
-            } elseif ($this->isLikeEnabled) {
-                $element->setAttribute('data-feedback', 'fb:likes');
-            } else {
-                $element->setAttribute('data-feedback', 'fb:comments');
-            }
-        }
 
         // Presentation
         if ($this->presentation) {
@@ -393,10 +358,10 @@ class Image extends Audible
      * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable likes on images per default or false to disable like on images.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public static function setDefaultLikeEnabled($enabled)
     {
-        self::$defaultLikeEnabled = $enabled;
     }
 
     /**
@@ -405,9 +370,9 @@ class Image extends Audible
      * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable comments on images per default or false to disable commenting on images.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public static function setDefaultCommentEnabled($enabled)
     {
-        self::$defaultCommentEnabled = $enabled;
     }
 }

--- a/src/Facebook/InstantArticles/Elements/Video.php
+++ b/src/Facebook/InstantArticles/Elements/Video.php
@@ -45,16 +45,6 @@ class Video extends Element implements ChildrenContainer
     const DATA_FADE = 'data-fade';
 
     /**
-     * @var boolean marks if any created image will have likes enabled by default
-     */
-    private static $defaultLikeEnabled = false;
-
-    /**
-     * @var boolean marks if any created image will have comments enabled by default
-     */
-    private static $defaultCommentEnabled = false;
-
-    /**
      * @var Caption The caption for Video
      */
     private $caption;
@@ -69,16 +59,6 @@ class Video extends Element implements ChildrenContainer
      * @var string The video content type. Default: "video/mp4"
      */
     private $contentType;
-
-    /**
-     * @var boolean Tells if like is enabled. Default: false
-     */
-    private $isLikeEnabled;
-
-    /**
-     * @var boolean Tells if comments are enabled. Default: false
-     */
-    private $isCommentsEnabled;
 
     /**
      * @var boolean Makes the video the cover on news feed.
@@ -124,8 +104,6 @@ class Video extends Element implements ChildrenContainer
 
     private function __construct()
     {
-        $this->isLikeEnabled = self::$defaultLikeEnabled;
-        $this->isCommentsEnabled = self::$defaultCommentEnabled;
     }
 
     /**
@@ -201,11 +179,10 @@ class Video extends Element implements ChildrenContainer
      * Makes like enabled for this video.
      *
      * @return $this
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function enableLike()
     {
-        $this->isLikeEnabled = true;
-
         return $this;
     }
 
@@ -213,11 +190,10 @@ class Video extends Element implements ChildrenContainer
      * Makes like disabled for this video.
      *
      * @return $this
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function disableLike()
     {
-        $this->isLikeEnabled = false;
-
         return $this;
     }
 
@@ -225,11 +201,10 @@ class Video extends Element implements ChildrenContainer
      * Makes comments enabled for this video.
      *
      * @return $this
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function enableComments()
     {
-        $this->isCommentsEnabled = true;
-
         return $this;
     }
 
@@ -237,11 +212,10 @@ class Video extends Element implements ChildrenContainer
      * Makes comments disabled for this video.
      *
      * @return $this
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function disableComments()
     {
-        $this->isCommentsEnabled = false;
-
         return $this;
     }
 
@@ -394,10 +368,11 @@ class Video extends Element implements ChildrenContainer
 
     /**
      * @return boolean tells if the like button is enabled
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function isLikeEnabled()
     {
-        return $this->isLikeEnabled;
+        return false;
     }
 
     /**
@@ -410,10 +385,11 @@ class Video extends Element implements ChildrenContainer
 
     /**
      * @return boolean tells if the comments widget is enabled
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public function isCommentsEnabled()
     {
-        return $this->isCommentsEnabled;
+        return false;
     }
 
     /**
@@ -451,10 +427,10 @@ class Video extends Element implements ChildrenContainer
      * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable likes on videos per default or false to disable like on videos.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public static function setDefaultLikeEnabled($enabled)
     {
-        self::$defaultLikeEnabled = $enabled;
     }
 
     /**
@@ -463,10 +439,10 @@ class Video extends Element implements ChildrenContainer
      * WARNING this is not Thread-safe, so if you are using pthreads or any other multithreaded engine,
      * this might not work as expected. (you will need to set this in all working threads manually)
      * @param boolean $enabled inform true to enable comments on videos per default or false to disable commenting on videos.
+     * @deprecated This feature has been deprecated as InstantArticles doesn't support likes, comments and shares to individual media content.
      */
     public static function setDefaultCommentEnabled($enabled)
     {
-        self::$defaultCommentEnabled = $enabled;
     }
 
 
@@ -499,17 +475,6 @@ class Video extends Element implements ChildrenContainer
 
         if ($this->isFeedCover) {
             $element->setAttribute('class', 'fb-feed-cover');
-        }
-
-        // Like/comments markup optional
-        if ($this->isLikeEnabled || $this->isCommentsEnabled) {
-            if ($this->isLikeEnabled && $this->isCommentsEnabled) {
-                $element->setAttribute('data-feedback', 'fb:likes,fb:comments');
-            } elseif ($this->isLikeEnabled) {
-                $element->setAttribute('data-feedback', 'fb:likes');
-            } else {
-                $element->setAttribute('data-feedback', 'fb:comments');
-            }
         }
 
         // URL markup required

--- a/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
+++ b/src/Facebook/InstantArticles/Parser/instant-articles-rules.json
@@ -465,11 +465,6 @@
                         "selector" : "img",
                         "attribute": "src"
                     },
-                    "image.like" : {
-                        "type" : "exists",
-                        "selector" : "figure[data-feedback*='fb:likes']",
-                        "attribute": "data-feedback"
-                    },
                     "aspect-fit": {
                         "type": "exists",
                         "selector" : "figure[data-mode=aspect-fit]"
@@ -485,11 +480,6 @@
                     "non-interactive": {
                         "type": "exists",
                         "selector" : "figure[data-mode=non-interactive]"
-                    },
-                    "image.comments" : {
-                        "type" : "exists",
-                        "selector" : "figure[data-feedback*='fb:comments']",
-                        "attribute": "data-feedback"
                     }
                 }
             },
@@ -533,16 +523,6 @@
                         "type": "exists",
                         "selector" : "video",
                         "attribute": "data-fb-disable-autoplay"
-                    },
-                    "video.like" : {
-                        "type" : "exists",
-                        "selector" : "figure[data-feedback*='fb:likes']",
-                        "attribute": "data-feedback"
-                    },
-                    "video.comments" : {
-                        "type" : "exists",
-                        "selector" : "figure[data-feedback*='fb:comments']",
-                        "attribute": "data-feedback"
                     }
                 }
             },

--- a/tests/Facebook/InstantArticles/Elements/ImageTest.php
+++ b/tests/Facebook/InstantArticles/Elements/ImageTest.php
@@ -94,7 +94,7 @@ class ImageTest extends BaseHTMLTestCase
                 ->enableLike();
 
         $expected =
-            '<figure data-feedback="fb:likes">'.
+            '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
                 '<figcaption>Some caption to the image</figcaption>'.
             '</figure>';
@@ -115,7 +115,7 @@ class ImageTest extends BaseHTMLTestCase
                 ->enableComments();
 
         $expected =
-            '<figure data-feedback="fb:comments">'.
+            '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
                 '<figcaption>Some caption to the image</figcaption>'.
             '</figure>';
@@ -137,7 +137,7 @@ class ImageTest extends BaseHTMLTestCase
               ->enableComments();
 
         $expected =
-            '<figure data-feedback="fb:likes,fb:comments">'.
+            '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
                 '<figcaption>Some caption to the image</figcaption>'.
             '</figure>';
@@ -159,7 +159,7 @@ class ImageTest extends BaseHTMLTestCase
               ->enableComments();
 
         $expected =
-            '<figure data-feedback="fb:likes,fb:comments">'.
+            '<figure>'.
                 '<img src="https://jpeg.org/images/jpegls-home.jpg?width=100&height=200"/>'.
                 '<figcaption>Some caption to the image</figcaption>'.
             '</figure>';

--- a/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
+++ b/tests/Facebook/InstantArticles/Elements/SlideshowTest.php
@@ -70,13 +70,13 @@ class SlideshowTest extends BaseHTMLTestCase
 
         $expected =
             '<figure class="op-slideshow">'.
-                '<figure data-feedback="fb:likes">'.
+                '<figure>'.
                     '<img src="https://jpeg.org/images/jpegls-home.jpg"/>'.
                 '</figure>'.
-                '<figure data-feedback="fb:comments">'.
+                '<figure>'.
                     '<img src="https://jpeg.org/images/jpegls-home2.jpg"/>'.
                 '</figure>'.
-                '<figure data-feedback="fb:likes,fb:comments">'.
+                '<figure>'.
                     '<img src="https://jpeg.org/images/jpegls-home3.jpg"/>'.
                 '</figure>'.
             '</figure>';

--- a/tests/Facebook/InstantArticles/Elements/VideoTest.php
+++ b/tests/Facebook/InstantArticles/Elements/VideoTest.php
@@ -148,7 +148,7 @@ class VideoTest extends BaseHTMLTestCase
                 ->enableLike();
 
         $expected =
-            '<figure data-feedback="fb:likes">'.
+            '<figure>'.
                 '<video>'.
                     '<source src="http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_1mb.mp4"/>'.
                 '</video>'.
@@ -171,7 +171,7 @@ class VideoTest extends BaseHTMLTestCase
                 ->enableComments();
 
         $expected =
-            '<figure data-feedback="fb:comments">'.
+            '<figure>'.
                 '<video>'.
                     '<source src="http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_1mb.mp4"/>'.
                 '</video>'.
@@ -195,7 +195,7 @@ class VideoTest extends BaseHTMLTestCase
                 ->enableComments();
 
         $expected =
-            '<figure data-feedback="fb:likes,fb:comments">'.
+            '<figure>'.
                 '<video>'.
                     '<source src="http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_1mb.mp4"/>'.
                 '</video>'.

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-no-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-no-timezone.html
@@ -31,13 +31,13 @@
         <h3 class="op-kicker">Some kicker of this article</h3>
       </header>
       <p>Some text to be within a paragraph for testing.</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -58,7 +58,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
       </figure>
@@ -143,7 +143,7 @@
           <h1>Custom code for your social embed</h1>
           <script>alert("test & more test");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-nyc-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-nyc-timezone.html
@@ -31,13 +31,13 @@
         <h3 class="op-kicker">Some kicker of this article</h3>
       </header>
       <p>Some text to be within a paragraph for testing.</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -58,7 +58,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
       </figure>
@@ -143,7 +143,7 @@
           <h1>Custom code for your social embed</h1>
           <script>alert("test & more test");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example-standard-timezone.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example-standard-timezone.html
@@ -31,13 +31,13 @@
         <h3 class="op-kicker">Some kicker of this article</h3>
       </header>
       <p>Some text to be within a paragraph for testing.</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -58,7 +58,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
       </figure>
@@ -143,7 +143,7 @@
           <h1>Custom code for your social embed</h1>
           <script>alert("test & more test");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Parser/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Parser/instant-article-example.html
@@ -32,13 +32,13 @@
         <h3 class="op-kicker">Some kicker of this article</h3>
       </header>
       <p>Some text to be within a paragraph for testing.</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -59,7 +59,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
       </figure>
@@ -144,7 +144,7 @@
           <h1>Custom code for your social embed</h1>
           <script>alert("test & more test");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-multibyte.html
@@ -36,13 +36,13 @@
         </ul>
       </header>
       <p>パラグラフ内のテキストのテストです。</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -63,7 +63,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>イメージ名</h1>テキストノード<cite>イメージキャプション</cite></figcaption>
       </figure>
@@ -148,7 +148,7 @@
           <h1>ソーシャル埋め込み用カスタムコード</h1>
           <script>alert("テスト");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example-nonutf8.html
@@ -36,13 +36,13 @@
         </ul>
       </header>
       <p>パラグラフ内のテキストのテストです。</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="&#x30AA;&#x30FC;&#x30C7;&#x30A3;&#x30AA;&#x30BF;&#x30A4;&#x30C8;&#x30EB;" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -63,7 +63,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>イメージ名</h1>テキストノード<cite>イメージキャプション</cite></figcaption>
       </figure>
@@ -148,7 +148,7 @@
           <h1>ソーシャル埋め込み用カスタムコード</h1>
           <script>alert("テスト");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>

--- a/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
+++ b/tests/Facebook/InstantArticles/Transformer/instant-article-example.html
@@ -36,13 +36,13 @@
         </ul>
       </header>
       <p>Some text to be within a paragraph for testing.</p>
-      <figure data-feedback="fb:likes">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <audio title="audio title" autoplay="autoplay" muted="muted">
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:comments">
+      <figure>
         <img src="http://mydomain.com/path/to/img.jpg"/>
         <script type="application/json" class="op-geotag">
           {
@@ -63,7 +63,7 @@
           <source src="http://foo.com/mp3"/>
         </audio>
       </figure>
-      <figure data-feedback="fb:likes,fb:comments">
+      <figure>
         <img src="https://jpeg.org/images/jpegls-home.jpg"/>
         <figcaption><h1>Image Name</h1>Some text on text node<cite>Some caption to the image</cite></figcaption>
       </figure>
@@ -148,7 +148,7 @@
           <h1>Custom code for your social embed</h1>
           <script>alert("test & more test");</script></iframe>
       </figure>
-      <figure data-mode="fullscreen" data-feedback="fb:likes,fb:comments">
+      <figure data-mode="fullscreen">
         <video data-fb-disable-autoplay="data-fb-disable-autoplay" controls="controls">
           <source src="http://mydomain.com/path/to/video.mp4" type="video/mp4"/>
         </video>


### PR DESCRIPTION
This deprecated all the acessor methods to the properties of shares, comments and likes.
- Removes the properties from media elements: Image and Video
- Adapts test cases to not expect the data-feedback property to be set
- Keeps code as non-breaking change
- Removes any rule setting to read/interpret the data-feedback property
- Adds @deprecated annotation to all methods affected

