### PR TITLE
Fix #346 - Transformer's transform method does not account for settings

### DIFF
--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -478,6 +478,13 @@ class InstantArticle extends Element implements ChildrenContainer, InstantArticl
         return $this;
     }
 
+    public function getMetaProperty($property_name) {
+        if (array_key_exists($property_name, $this->metaProperties)) {
+            return $this->metaProperties[$property_name];
+        }
+        return null;
+    }
+
     public function render($doctype = '<!doctype html>', $format = false, $validate = true)
     {
         $doctype = is_null($doctype) ? '<!doctype html>' : $doctype;

--- a/src/Facebook/InstantArticles/Elements/InstantArticle.php
+++ b/src/Facebook/InstantArticles/Elements/InstantArticle.php
@@ -478,7 +478,8 @@ class InstantArticle extends Element implements ChildrenContainer, InstantArticl
         return $this;
     }
 
-    public function getMetaProperty($property_name) {
+    public function getMetaProperty($property_name)
+    {
         if (array_key_exists($property_name, $this->metaProperties)) {
             return $this->metaProperties[$property_name];
         }

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -263,9 +263,6 @@ class Transformer
         libxml_clear_errors();
         libxml_use_internal_errors($libxml_previous_state);
         $result = $this->transform($context, $document);
-        if (Type::is($result, InstantArticle::getClassName())) {
-            $result = $this->handleTransformationSettings($result);
-        }
         $totalTime = round(microtime(true) - $start, 3)*1000;
         $totalWarnings = count($this->getWarnings());
         $this->addLog(
@@ -284,9 +281,11 @@ class Transformer
      */
     public function transform($context, $node)
     {
-        if (Type::is($context, InstantArticle::getClassName())) {
+        $is_top_of_recursion_stack = false;
+        if (Type::is($context, InstantArticle::getClassName()) && $context->getMetaProperty('op:generator:transformer') === null) {
             $context->addMetaProperty('op:generator:transformer', 'facebook-instant-articles-sdk-php');
             $context->addMetaProperty('op:generator:transformer:version', InstantArticle::CURRENT_VERSION);
+            $is_top_of_recursion_stack = true;
             $this->instantArticle = $context;
         }
 
@@ -373,6 +372,10 @@ class Transformer
                     $this->addWarning(new UnrecognizedElement($current_context, $child));
                 }
             }
+        }
+
+        if ($is_top_of_recursion_stack) {
+          $context = $this->handleTransformationSettings($context);
         }
 
         return $context;

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -275,17 +275,16 @@ class Transformer
     /**
      * @param InstantArticle $context
      * @param \DOMNode $node
-     * @deprecated Use @see Transformer::transformString instead.
      *
      * @return mixed
      */
     public function transform($context, $node)
     {
-        $is_top_of_recursion_stack = false;
+        $is_first_run = false;
         if (Type::is($context, InstantArticle::getClassName()) && $context->getMetaProperty('op:generator:transformer') === null) {
             $context->addMetaProperty('op:generator:transformer', 'facebook-instant-articles-sdk-php');
             $context->addMetaProperty('op:generator:transformer:version', InstantArticle::CURRENT_VERSION);
-            $is_top_of_recursion_stack = true;
+            $is_first_run = true;
             $this->instantArticle = $context;
         }
 
@@ -374,8 +373,8 @@ class Transformer
             }
         }
 
-        if ($is_top_of_recursion_stack) {
-          $context = $this->handleTransformationSettings($context);
+        if ($is_first_run) {
+            $context = $this->handleTransformationSettings($context);
         }
 
         return $context;

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -24,7 +24,12 @@ class SimpleTransformerTest extends BaseHTMLTestCase
 
         $html_file = file_get_contents(__DIR__ . '/simple.html');
 
-        $transformer->transformString($instant_article, $html_file);
+        libxml_use_internal_errors(true);
+        $document = new \DOMDocument();
+        $document->loadHTML($html_file);
+        libxml_use_internal_errors(false);
+
+        $transformer->transform($instant_article, $document);
         $instant_article->addMetaProperty('op:generator:version', '1.0.0');
         $instant_article->addMetaProperty('op:generator:transformer:version', '1.0.0');
         $result = $instant_article->render('', true)."\n";


### PR DESCRIPTION
This PR

* [x] Fixes the `Transformer::transform` method to use the transformationSettings the same way as `Transformer::transformString`

Fixes #346 
