### PR TITLE
Drop unsupported PHP version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ env:
 
 matrix:
   include:
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
-    - php: 7
     - php: 7.1
+    - php: 7.2
       env: WITH_CS=true GITHUB_TOKEN=fbc9f8b635109c0c7ad64013ff8346908389f5f9
 
 cache:


### PR DESCRIPTION
Pre-installed version in xenial are only `5.6`, `7.1` and `7.2`.

https://docs.travis-ci.com/user/reference/xenial#php-support