### PR TITLE
Fix strpos() deprecation notice

### DIFF
--- a/src/Facebook/InstantArticles/Elements/Author.php
+++ b/src/Facebook/InstantArticles/Elements/Author.php
@@ -173,7 +173,7 @@ class Author extends Element
             $document = new \DOMDocument();
         }
 
-        $author_url = $this->url ? $this->url : null;
+        $author_url = $this->url ? $this->url : '';
         $is_fb_author = strpos($author_url, 'facebook.com') !== false;
 
         // Creates the root tag <address></address>


### PR DESCRIPTION
PHP 8.1 generates a deprecation notice:

> strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

This changes the `null` to an empty string if it hasn't been set.